### PR TITLE
feat: REPL apt list --installed and pip list pseudo-commands (#23)

### DIFF
--- a/src/repl/commands/apt.rs
+++ b/src/repl/commands/apt.rs
@@ -1,0 +1,221 @@
+// `apt list --installed` command — show simulated apt packages.
+//
+// Prints packages recorded in `state.installed.apt` using Debian-style
+// `apt list --installed` output format. When the `--installed` flag is not
+// given, prints a usage hint instead.
+//
+// This is a simulation: no real package resolution is performed. The output
+// is derived entirely from what the engine recorded during `RUN apt-get install`
+// processing.
+
+use std::io::Write;
+
+use crate::model::state::PreviewState;
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::error::ReplError;
+
+/// Execute the `apt list [--installed]` command.
+///
+/// When `installed` is `false`, prints a usage hint and returns early.
+/// When `installed` is `true`, prints the Debian-style listing of all
+/// simulated apt packages from the registry, one per line:
+///
+/// ```text
+/// Listing...
+/// <package>/simulated [installed,simulated]
+/// ```
+///
+/// If no packages are recorded, prints `"(no packages recorded)\n"` instead
+/// of an empty listing, to match the real `apt list --installed` sentinel.
+///
+/// Package names are sanitized before output to prevent terminal escape injection.
+pub fn execute(
+    state: &PreviewState,
+    installed: bool,
+    writer: &mut impl Write,
+) -> Result<(), ReplError> {
+    // Map I/O errors into ReplError so callers see a consistent error type.
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: "apt".to_string(),
+        message: e.to_string(),
+    };
+
+    if !installed {
+        // No --installed flag — show usage hint, not the full listing.
+        writeln!(writer, "Usage: apt list --installed").map_err(io_err)?;
+        return Ok(());
+    }
+
+    // --installed flag given — produce the Debian-style listing.
+    writeln!(writer, "Listing...").map_err(io_err)?;
+
+    let packages = state.installed.list("apt");
+    if packages.is_empty() {
+        writeln!(writer, "(no packages recorded)").map_err(io_err)?;
+    } else {
+        for pkg in &packages {
+            // Sanitize each package name before writing; package names come
+            // from engine-processed Dockerfile text which may contain escape bytes.
+            let safe_pkg = sanitize_for_terminal(pkg);
+            writeln!(writer, "{safe_pkg}/simulated [installed,simulated]").map_err(io_err)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::state::PreviewState;
+
+    /// Helper: run execute with --installed flag and capture output as String.
+    fn run_installed(state: &PreviewState) -> String {
+        let mut buf = Vec::new();
+        execute(state, true, &mut buf).expect("apt execute should not fail");
+        String::from_utf8(buf).unwrap()
+    }
+
+    /// Helper: run execute without --installed flag and capture output as String.
+    fn run_no_flag(state: &PreviewState) -> String {
+        let mut buf = Vec::new();
+        execute(state, false, &mut buf).expect("apt execute should not fail");
+        String::from_utf8(buf).unwrap()
+    }
+
+    // --- Empty registry ---
+
+    #[test]
+    fn apt_list_installed_empty_registry() {
+        let state = PreviewState::default();
+        let out = run_installed(&state);
+        assert!(
+            out.contains("Listing..."),
+            "must start with 'Listing...'; got: {out}"
+        );
+        assert!(
+            out.contains("(no packages recorded)"),
+            "empty registry must print sentinel; got: {out}"
+        );
+    }
+
+    // --- Single package ---
+
+    #[test]
+    fn apt_list_installed_single_package() {
+        let mut state = PreviewState::default();
+        state.installed.record("apt", "curl".to_string());
+        let out = run_installed(&state);
+        assert!(out.contains("Listing..."), "got: {out}");
+        assert!(
+            out.contains("curl/simulated [installed,simulated]"),
+            "must contain Debian-style line for curl; got: {out}"
+        );
+        // Empty-registry sentinel must NOT appear when there are packages.
+        assert!(
+            !out.contains("(no packages recorded)"),
+            "sentinel must not appear when packages are present; got: {out}"
+        );
+    }
+
+    // --- Multiple packages in alphabetical order ---
+
+    #[test]
+    fn apt_list_installed_multiple_packages_alphabetical() {
+        let mut state = PreviewState::default();
+        // Insert in reverse alphabetical order — BTreeSet will sort them.
+        state.installed.record("apt", "wget".to_string());
+        state.installed.record("apt", "bash".to_string());
+        state.installed.record("apt", "curl".to_string());
+        let out = run_installed(&state);
+        // Verify all three appear.
+        assert!(
+            out.contains("bash/simulated [installed,simulated]"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("curl/simulated [installed,simulated]"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("wget/simulated [installed,simulated]"),
+            "got: {out}"
+        );
+        // Verify alphabetical order: bash < curl < wget.
+        let bash_pos = out.find("bash/simulated").expect("bash must appear");
+        let curl_pos = out.find("curl/simulated").expect("curl must appear");
+        let wget_pos = out.find("wget/simulated").expect("wget must appear");
+        assert!(
+            bash_pos < curl_pos,
+            "bash must come before curl; got:\n{out}"
+        );
+        assert!(
+            curl_pos < wget_pos,
+            "curl must come before wget; got:\n{out}"
+        );
+    }
+
+    // --- No --installed flag prints usage ---
+
+    #[test]
+    fn apt_list_no_flag_prints_usage() {
+        let state = PreviewState::default();
+        let out = run_no_flag(&state);
+        assert!(
+            out.contains("Usage: apt list --installed"),
+            "must print usage hint when flag omitted; got: {out}"
+        );
+        // Must NOT print the listing header.
+        assert!(
+            !out.contains("Listing..."),
+            "must not print listing header when flag omitted; got: {out}"
+        );
+    }
+
+    // --- Escape sequence and control character sanitization ---
+
+    #[test]
+    fn apt_list_sanitizes_embedded_newline_in_package_name() {
+        // An embedded \n in a package name must not produce an extra output line.
+        // sanitize_for_terminal strips C0 control characters including LF (0x0A).
+        let mut state = PreviewState::default();
+        state.installed.apt.insert("curl\necho pwned".to_string());
+        let buf = {
+            let mut b = Vec::new();
+            execute(&state, true, &mut b).expect("should succeed");
+            b
+        };
+        let out = String::from_utf8(buf).expect("utf-8");
+        // Only one data line should appear (the "Listing..." header is the other line).
+        let data_lines: Vec<&str> = out.lines().filter(|l| l.contains("/simulated")).collect();
+        assert_eq!(
+            data_lines.len(),
+            1,
+            "embedded newline must not produce extra output lines; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn apt_list_sanitizes_escape_sequences() {
+        let mut state = PreviewState::default();
+        // Insert directly into the BTreeSet to bypass record() string handling.
+        state.installed.apt.insert("curl\x1b[2J".to_string());
+        let buf = {
+            let mut b = Vec::new();
+            execute(&state, true, &mut b).expect("should succeed");
+            b
+        };
+        // ESC byte (0x1B) must not appear in the printed output.
+        assert!(
+            !buf.contains(&0x1B),
+            "ESC must be stripped from apt list output"
+        );
+        // The sanitized base name must still be present.
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert!(
+            out.contains("curl"),
+            "base name must survive sanitization; got:\n{out}"
+        );
+    }
+}

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -25,6 +25,8 @@ COMMANDS
   cat <path>               print file contents
   find <path> [-name pat]  search filesystem for files
   env                      print environment variables
+  apt list --installed     list simulated apt packages
+  pip list                 list simulated pip packages
   which <cmd>              show simulated binary path for a command
   help                     show this help message
   exit                     leave the REPL
@@ -111,5 +113,20 @@ mod tests {
         let state = PreviewState::default();
         let mut buf = Vec::new();
         assert!(execute(&state, &mut buf).is_ok());
+    }
+
+    // --- New commands from issue #23 ---
+
+    #[test]
+    fn help_contains_apt_list_installed() {
+        assert!(
+            run().contains("apt list --installed"),
+            "output must mention 'apt list --installed'"
+        );
+    }
+
+    #[test]
+    fn help_contains_pip_list() {
+        assert!(run().contains("pip list"), "output must mention 'pip list'");
     }
 }

--- a/src/repl/commands/mod.rs
+++ b/src/repl/commands/mod.rs
@@ -5,11 +5,13 @@
 // output sink. Using a writer rather than printing to stdout directly keeps
 // all handlers fully testable without capturing stdout.
 
+pub mod apt;
 pub mod cat;
 pub mod cd;
 pub mod env_cmd;
 pub mod find;
 pub mod help;
 pub mod ls;
+pub mod pip;
 pub mod pwd;
 pub mod which;

--- a/src/repl/commands/pip.rs
+++ b/src/repl/commands/pip.rs
@@ -1,0 +1,180 @@
+// `pip list` command — show simulated pip packages.
+//
+// Prints packages recorded in `state.installed.pip` in the same tabular
+// format as the real `pip list` command:
+//
+//   Package    Version
+//   ---------- -------
+//   requests   (simulated)
+//
+// This is a simulation: no real package data is fetched. The output comes
+// entirely from what the engine recorded during `RUN pip install` processing.
+
+use std::io::Write;
+
+use crate::model::state::PreviewState;
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::error::ReplError;
+
+/// Column width for the Package name field.
+///
+/// Matches real `pip list` behaviour: the Package column is at least 10 chars
+/// wide. Names longer than 10 chars extend naturally beyond the column.
+const PKG_COL_WIDTH: usize = 10;
+
+/// Execute the `pip list` command.
+///
+/// Always writes the pip table header and separator, then one row per
+/// recorded pip package. When the registry is empty, only the header
+/// and separator are printed (matching real `pip list` behaviour on an
+/// empty environment).
+///
+/// Package names are sanitized before output to prevent terminal escape injection.
+pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
+    // Map I/O errors into ReplError so callers see a consistent error type.
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: "pip".to_string(),
+        message: e.to_string(),
+    };
+
+    // Always write the header and separator, even for an empty registry.
+    writeln!(writer, "Package    Version").map_err(io_err)?;
+    writeln!(writer, "---------- -------").map_err(io_err)?;
+
+    let packages = state.installed.list("pip");
+    for pkg in &packages {
+        // Sanitize each package name before writing; package names originate from
+        // engine-processed Dockerfile text which may contain escape bytes.
+        let safe_pkg = sanitize_for_terminal(pkg);
+        writeln!(writer, "{safe_pkg:<PKG_COL_WIDTH$} (simulated)").map_err(io_err)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::state::PreviewState;
+
+    /// Helper: run execute and capture output as String.
+    fn run(state: &PreviewState) -> String {
+        let mut buf = Vec::new();
+        execute(state, &mut buf).expect("pip execute should not fail");
+        String::from_utf8(buf).unwrap()
+    }
+
+    // --- Empty registry prints header only ---
+
+    #[test]
+    fn pip_list_empty_registry_prints_header_only() {
+        let state = PreviewState::default();
+        let out = run(&state);
+        assert!(
+            out.contains("Package    Version"),
+            "must contain header; got: {out}"
+        );
+        assert!(
+            out.contains("---------- -------"),
+            "must contain separator; got: {out}"
+        );
+        // No data rows should appear when registry is empty.
+        assert!(
+            !out.contains("(simulated)"),
+            "must not print data rows for empty registry; got: {out}"
+        );
+    }
+
+    // --- Single package ---
+
+    #[test]
+    fn pip_list_single_package() {
+        let mut state = PreviewState::default();
+        state.installed.record("pip", "requests".to_string());
+        let out = run(&state);
+        assert!(
+            out.contains("Package    Version"),
+            "header missing; got: {out}"
+        );
+        assert!(
+            out.contains("---------- -------"),
+            "separator missing; got: {out}"
+        );
+        // Assert the combined, column-aligned row so a split-line regression
+        // would not pass. "requests" (8 chars) padded to 10 + 1 space = 3 spaces.
+        assert!(
+            out.contains("requests   (simulated)"),
+            "must show column-aligned row for requests; got: {out}"
+        );
+    }
+
+    // --- Multiple packages in alphabetical order ---
+
+    #[test]
+    fn pip_list_multiple_packages_alphabetical() {
+        let mut state = PreviewState::default();
+        // Insert in reverse alphabetical order — BTreeSet will sort them.
+        state.installed.record("pip", "requests".to_string());
+        state.installed.record("pip", "flask".to_string());
+        state.installed.record("pip", "django".to_string());
+        let out = run(&state);
+        // All three must appear.
+        assert!(out.contains("django"), "got: {out}");
+        assert!(out.contains("flask"), "got: {out}");
+        assert!(out.contains("requests"), "got: {out}");
+        // Alphabetical order: django < flask < requests.
+        let django_pos = out.find("django").expect("django must appear");
+        let flask_pos = out.find("flask").expect("flask must appear");
+        let requests_pos = out.find("requests").expect("requests must appear");
+        assert!(
+            django_pos < flask_pos,
+            "django must precede flask; got:\n{out}"
+        );
+        assert!(
+            flask_pos < requests_pos,
+            "flask must precede requests; got:\n{out}"
+        );
+    }
+
+    // --- Column alignment for short names ---
+
+    #[test]
+    fn pip_list_column_alignment() {
+        // "os" is 2 chars. PKG_COL_WIDTH=10 left-pads it to 10 chars with :<10
+        // (adding 8 spaces), then the format literal adds one more space before
+        // "(simulated)", yielding 9 spaces total between the name and the version.
+        let mut state = PreviewState::default();
+        state.installed.record("pip", "os".to_string());
+        let out = run(&state);
+        assert!(
+            out.contains("os         (simulated)"),
+            "short name must be padded to align with version column; got:\n{out}"
+        );
+    }
+
+    // --- Escape sequence sanitization ---
+
+    #[test]
+    fn pip_list_sanitizes_escape_sequences() {
+        let mut state = PreviewState::default();
+        // Insert directly into the BTreeSet to bypass record() string handling.
+        state.installed.pip.insert("requests\x1b[2J".to_string());
+        let buf = {
+            let mut b = Vec::new();
+            execute(&state, &mut b).expect("should succeed");
+            b
+        };
+        // ESC byte (0x1B) must not appear in the printed output.
+        assert!(
+            !buf.contains(&0x1B),
+            "ESC must be stripped from pip list output"
+        );
+        // The sanitized base name must still be present.
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert!(
+            out.contains("requests"),
+            "base name must survive sanitization; got:\n{out}"
+        );
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -24,7 +24,7 @@ use rustyline::DefaultEditor;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::repl::commands::{cat, cd, env_cmd, find, help, ls, pwd, which};
+use crate::repl::commands::{apt, cat, cd, env_cmd, find, help, ls, pip, pwd, which};
 use crate::repl::custom::{history, installed, layers};
 use crate::repl::error::ReplError;
 use crate::repl::parse::{parse_input, ParsedCommand};
@@ -136,6 +136,12 @@ pub fn dispatch(
         }
         ParsedCommand::Installed => {
             installed::execute(state, writer)?;
+        }
+        ParsedCommand::AptList { installed } => {
+            apt::execute(state, installed, writer)?;
+        }
+        ParsedCommand::PipList => {
+            pip::execute(state, writer)?;
         }
         ParsedCommand::Which { cmd } => {
             which::execute(state, &cmd, writer)?;
@@ -450,6 +456,105 @@ mod tests {
         let apt_pos = out.find("apt:").expect("apt line must exist");
         let pip_pos = out.find("pip:").expect("pip line must exist");
         assert!(apt_pos < pip_pos, "apt must appear before pip; got:\n{out}");
+    }
+
+    // --- apt list dispatch ---
+
+    #[test]
+    fn dispatch_apt_list_installed_empty_prints_listing() {
+        let mut state = PreviewState::default();
+        let (cont, out) = dispatch_str(&mut state, "apt list --installed").expect("should succeed");
+        assert!(
+            cont,
+            "apt list --installed must return true (keep REPL running)"
+        );
+        assert!(
+            out.contains("Listing..."),
+            "must contain 'Listing...'; got: {out}"
+        );
+        assert!(
+            out.contains("(no packages recorded)"),
+            "empty registry sentinel must appear; got: {out}"
+        );
+    }
+
+    #[test]
+    fn dispatch_apt_list_installed_with_packages() {
+        let mut state = PreviewState::default();
+        state.installed.record("apt", "curl".to_string());
+        let (cont, out) = dispatch_str(&mut state, "apt list --installed").expect("should succeed");
+        assert!(cont);
+        assert!(
+            out.contains("curl/simulated [installed,simulated]"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn dispatch_apt_list_without_installed_flag_prints_usage() {
+        let mut state = PreviewState::default();
+        let (cont, out) = dispatch_str(&mut state, "apt list").expect("should succeed");
+        assert!(cont);
+        assert!(
+            out.contains("Usage: apt list --installed"),
+            "must print usage when --installed flag omitted; got: {out}"
+        );
+    }
+
+    #[test]
+    fn dispatch_apt_bare_is_unknown() {
+        let mut state = PreviewState::default();
+        let result = dispatch_str(&mut state, "apt");
+        assert!(
+            matches!(result, Err(ReplError::UnknownCommand { .. })),
+            "bare 'apt' must return UnknownCommand; got: {result:?}"
+        );
+    }
+
+    // --- pip list dispatch ---
+
+    #[test]
+    fn dispatch_pip_list_empty_prints_header() {
+        let mut state = PreviewState::default();
+        let (cont, out) = dispatch_str(&mut state, "pip list").expect("should succeed");
+        assert!(cont, "pip list must return true (keep REPL running)");
+        assert!(
+            out.contains("Package    Version"),
+            "header missing; got: {out}"
+        );
+        assert!(
+            out.contains("---------- -------"),
+            "separator missing; got: {out}"
+        );
+        // No data rows should appear when registry is empty.
+        assert!(
+            !out.contains("(simulated)"),
+            "must not print data rows for empty registry; got: {out}"
+        );
+    }
+
+    #[test]
+    fn dispatch_pip_list_with_packages() {
+        let mut state = PreviewState::default();
+        state.installed.record("pip", "flask".to_string());
+        let (cont, out) = dispatch_str(&mut state, "pip list").expect("should succeed");
+        assert!(cont);
+        // Assert the combined, column-aligned row so a split-line regression
+        // would not pass. "flask" (5 chars) padded to 10 + 1 space = 6 spaces.
+        assert!(
+            out.contains("flask      (simulated)"),
+            "must show column-aligned row for flask; got: {out}"
+        );
+    }
+
+    #[test]
+    fn dispatch_pip_bare_is_unknown() {
+        let mut state = PreviewState::default();
+        let result = dispatch_str(&mut state, "pip");
+        assert!(
+            matches!(result, Err(ReplError::UnknownCommand { .. })),
+            "bare 'pip' must return UnknownCommand; got: {result:?}"
+        );
     }
 
     // --- :history dispatch ---

--- a/src/repl/parse.rs
+++ b/src/repl/parse.rs
@@ -49,6 +49,13 @@ pub enum ParsedCommand {
         /// The command name to look up. Empty string when no argument was given.
         cmd: String,
     },
+    /// `apt list [--installed]` — list simulated apt packages.
+    AptList {
+        /// Whether `--installed` flag was given.
+        installed: bool,
+    },
+    /// `pip list` — list simulated pip packages.
+    PipList,
     /// The input was empty or only whitespace.
     Empty,
     /// The input did not match any known command.
@@ -87,6 +94,8 @@ pub fn parse_input(line: &str) -> ParsedCommand {
         "exit" | "quit" => ParsedCommand::Exit,
         "help" => ParsedCommand::Help,
         // Standard commands with arguments.
+        "apt" => parse_apt(args, trimmed),
+        "pip" => parse_pip(args, trimmed),
         "which" => parse_which(args),
         // Colon-prefixed custom inspection commands.
         ":layers" => ParsedCommand::Layers,
@@ -178,6 +187,40 @@ fn parse_find(args: &[&str]) -> ParsedCommand {
     }
 
     ParsedCommand::Find { path, name_pattern }
+}
+
+/// Parse arguments for the `apt` command.
+///
+/// Only `apt list` and `apt list --installed` are modeled. All other `apt`
+/// sub-commands (install, update, upgrade, etc.) produce `Unknown` so the
+/// REPL can surface them as unsupported rather than silently ignoring them.
+///
+/// `trimmed` is the full trimmed input line, used for the `Unknown` variant.
+fn parse_apt(args: &[&str], trimmed: &str) -> ParsedCommand {
+    match args {
+        ["list", "--installed"] => ParsedCommand::AptList { installed: true },
+        ["list"] => ParsedCommand::AptList { installed: false },
+        // All other forms (bare apt, apt install, apt update, …) are unknown.
+        _ => ParsedCommand::Unknown {
+            input: trimmed.to_string(),
+        },
+    }
+}
+
+/// Parse arguments for the `pip` command.
+///
+/// Only `pip list` is modeled. All other `pip` sub-commands (install, freeze,
+/// show, etc.) produce `Unknown` so the REPL can surface them appropriately.
+///
+/// `trimmed` is the full trimmed input line, used for the `Unknown` variant.
+fn parse_pip(args: &[&str], trimmed: &str) -> ParsedCommand {
+    match args {
+        ["list"] => ParsedCommand::PipList,
+        // All other forms (bare pip, pip install, …) are unknown.
+        _ => ParsedCommand::Unknown {
+            input: trimmed.to_string(),
+        },
+    }
 }
 
 /// Parse arguments for the `which` command.
@@ -553,6 +596,127 @@ mod tests {
             parse_input(":INSTALLED"),
             ParsedCommand::Unknown {
                 input: ":INSTALLED".to_string()
+            }
+        );
+    }
+
+    // --- apt ---
+
+    #[test]
+    fn apt_list_installed_returns_apt_list_installed_true() {
+        assert_eq!(
+            parse_input("apt list --installed"),
+            ParsedCommand::AptList { installed: true }
+        );
+    }
+
+    #[test]
+    fn apt_list_returns_apt_list_installed_false() {
+        assert_eq!(
+            parse_input("apt list"),
+            ParsedCommand::AptList { installed: false }
+        );
+    }
+
+    #[test]
+    fn apt_bare_returns_unknown() {
+        assert_eq!(
+            parse_input("apt"),
+            ParsedCommand::Unknown {
+                input: "apt".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn apt_install_returns_unknown() {
+        assert_eq!(
+            parse_input("apt install curl"),
+            ParsedCommand::Unknown {
+                input: "apt install curl".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn apt_update_returns_unknown() {
+        assert_eq!(
+            parse_input("apt update"),
+            ParsedCommand::Unknown {
+                input: "apt update".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn apt_uppercase_is_unknown() {
+        // Commands are case-sensitive — APT is not apt.
+        assert_eq!(
+            parse_input("APT list --installed"),
+            ParsedCommand::Unknown {
+                input: "APT list --installed".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn apt_list_installed_with_extra_args_is_unknown() {
+        // Extra tokens after --installed are not recognised; the parser rejects
+        // to Unknown so the REPL surfaces an unsupported-command message.
+        assert_eq!(
+            parse_input("apt list --installed --verbose"),
+            ParsedCommand::Unknown {
+                input: "apt list --installed --verbose".to_string()
+            }
+        );
+    }
+
+    // --- pip ---
+
+    #[test]
+    fn pip_list_returns_pip_list() {
+        assert_eq!(parse_input("pip list"), ParsedCommand::PipList);
+    }
+
+    #[test]
+    fn pip_bare_returns_unknown() {
+        assert_eq!(
+            parse_input("pip"),
+            ParsedCommand::Unknown {
+                input: "pip".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn pip_install_returns_unknown() {
+        assert_eq!(
+            parse_input("pip install requests"),
+            ParsedCommand::Unknown {
+                input: "pip install requests".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn pip_uppercase_is_unknown() {
+        // Commands are case-sensitive — PIP is not pip.
+        assert_eq!(
+            parse_input("PIP list"),
+            ParsedCommand::Unknown {
+                input: "PIP list".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn pip_list_with_extra_flag_is_unknown() {
+        // `pip list --outdated` is not a modeled command; extra flags after
+        // `list` fall through to Unknown so the REPL surfaces the rejection.
+        assert_eq!(
+            parse_input("pip list --outdated"),
+            ParsedCommand::Unknown {
+                input: "pip list --outdated".to_string()
             }
         );
     }


### PR DESCRIPTION
## Summary

- Adds `apt list --installed` — Debian-style package listing from the simulated apt registry
- Adds `pip list` — pip tabular format listing from the simulated pip registry
- Both commands are read-only and sanitize all package names before terminal output
- `apt list` (no flag) shows a usage hint; `apt` bare and `pip` bare produce `unknown command`

## What changed

| File | Change |
|------|--------|
| `src/repl/commands/apt.rs` | NEW — `apt list [--installed]` handler |
| `src/repl/commands/pip.rs` | NEW — `pip list` handler |
| `src/repl/parse.rs` | Added `AptList { installed: bool }` and `PipList` variants + parse helpers |
| `src/repl/mod.rs` | Added dispatch arms and 7 integration tests |
| `src/repl/commands/help.rs` | Added both commands to help text |
| `src/repl/commands/mod.rs` | Registered new modules |

## Test plan

- [ ] 464 tests passing (`cargo test`)
- [ ] `cargo fmt -- --check` clean
- [ ] `cargo clippy -- -D warnings` clean
- [ ] TDD: tests written before implementation (RED → GREEN)
- [ ] Code review: APPROVED (no CRITICAL or HIGH blocking issues)
- [ ] Security review: PASS for new files; filed #33 for pre-existing `env_cmd.rs` gap
- [ ] QA review: NEEDS WORK items resolved — extra-args parse tests added, combined row assertions strengthened, negative empty-registry assertion added at dispatch layer
- [ ] Architect review: `io_err` extraction filed as #32; no trait abstraction needed at current scale

## Follow-up issues filed

- #32 — refactor: extract `io_err` closure to shared helper
- #33 — fix: sanitize env var keys/values in `env_cmd.rs`

Closes #23