### PR TITLE
feat: REPL :reload command (#24)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use demu::{
     engine, output::sanitize::sanitize_for_terminal, parser::dockerfile::parse_dockerfile,
-    repl::run_repl, Cli,
+    repl::config::ReplConfig, repl::run_repl, Cli,
 };
 
 /// Full CLI pipeline. Returns `Err` for any unrecoverable failure.
@@ -103,7 +103,11 @@ fn run_cli() -> Result<()> {
 
     // ── 7. Enter the interactive REPL ────────────────────────────────────────
 
-    run_repl(&mut state)?;
+    // Build the session-level config that the REPL needs for `:reload`.
+    // The canonical path and context_dir are already computed above.
+    let repl_config = ReplConfig::new(canonical);
+
+    run_repl(&mut state, &repl_config)?;
 
     Ok(())
 }

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -37,6 +37,7 @@ CUSTOM COMMANDS (prefix with :)
   :history                 show instruction history
   :installed               show simulated package installs
   :warnings                show simulation warnings
+  :reload                  re-read and re-process the Dockerfile
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
@@ -128,5 +129,13 @@ mod tests {
     #[test]
     fn help_contains_pip_list() {
         assert!(run().contains("pip list"), "output must mention 'pip list'");
+    }
+
+    #[test]
+    fn help_contains_reload() {
+        assert!(
+            run().contains(":reload"),
+            "output must mention ':reload' in the custom commands section"
+        );
     }
 }

--- a/src/repl/config.rs
+++ b/src/repl/config.rs
@@ -1,0 +1,100 @@
+// Session-level configuration for the REPL.
+//
+// `ReplConfig` holds the fixed session metadata that the REPL needs to support
+// `:reload`. These values are immutable after construction and are separate from
+// `PreviewState`, which holds simulation output.
+
+use std::path::PathBuf;
+
+/// Session-level configuration for the REPL.
+///
+/// Holds the fixed session metadata (Dockerfile path, build context directory)
+/// that the REPL needs to support `:reload`. These values are immutable after
+/// construction and are separate from `PreviewState`, which holds simulation output.
+pub struct ReplConfig {
+    /// Absolute path to the Dockerfile being previewed.
+    pub dockerfile_path: PathBuf,
+    /// Absolute path to the build context directory (parent of the Dockerfile).
+    ///
+    /// Derived automatically from `dockerfile_path.parent()` by `ReplConfig::new`.
+    /// If a different context directory is required, use `ReplConfig::with_context`.
+    pub context_dir: PathBuf,
+}
+
+impl ReplConfig {
+    /// Construct a `ReplConfig` from the Dockerfile path alone.
+    ///
+    /// The build context directory is derived as `dockerfile_path.parent()`, which
+    /// is the standard Docker build context for a project Dockerfile. If the path
+    /// has no parent component (an edge case for bare filenames), `/` is used.
+    ///
+    /// `dockerfile_path` should be an absolute, canonicalized path.
+    pub fn new(dockerfile_path: PathBuf) -> Self {
+        let context_dir = dockerfile_path
+            .parent()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/"));
+        Self {
+            dockerfile_path,
+            context_dir,
+        }
+    }
+
+    /// Construct a `ReplConfig` with an explicit build context directory.
+    ///
+    /// Use this when the context directory differs from the Dockerfile's parent —
+    /// for example, when a `--context` flag or Compose configuration specifies
+    /// a different root.
+    pub fn with_context(dockerfile_path: PathBuf, context_dir: PathBuf) -> Self {
+        Self {
+            dockerfile_path,
+            context_dir,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- ReplConfig::new derives context_dir from parent ---
+
+    #[test]
+    fn repl_config_new_derives_context_dir_from_parent() {
+        let df_path = PathBuf::from("/project/Dockerfile");
+        let config = ReplConfig::new(df_path.clone());
+        assert_eq!(config.dockerfile_path, df_path);
+        assert_eq!(config.context_dir, PathBuf::from("/project"));
+    }
+
+    #[test]
+    fn repl_config_new_nested_path_derives_correct_parent() {
+        let df_path = PathBuf::from("/home/user/app/Dockerfile");
+        let config = ReplConfig::new(df_path);
+        assert_eq!(config.context_dir, PathBuf::from("/home/user/app"));
+    }
+
+    // --- ReplConfig::with_context accepts explicit context directory ---
+
+    #[test]
+    fn repl_config_with_context_stores_custom_context_dir() {
+        let df_path = PathBuf::from("/project/docker/Dockerfile");
+        let ctx_dir = PathBuf::from("/project");
+        let config = ReplConfig::with_context(df_path.clone(), ctx_dir.clone());
+        assert_eq!(config.dockerfile_path, df_path);
+        assert_eq!(config.context_dir, ctx_dir);
+    }
+
+    // --- Public fields are directly accessible ---
+
+    #[test]
+    fn repl_config_fields_are_accessible() {
+        let config = ReplConfig::new(PathBuf::from("/app/Dockerfile"));
+        let _ = &config.dockerfile_path;
+        let _ = &config.context_dir;
+        assert_eq!(config.dockerfile_path, PathBuf::from("/app/Dockerfile"));
+        assert_eq!(config.context_dir, PathBuf::from("/app"));
+    }
+}

--- a/src/repl/custom/mod.rs
+++ b/src/repl/custom/mod.rs
@@ -1,9 +1,13 @@
 // Custom REPL inspection command handlers.
 //
-// Each submodule implements a colon-prefixed command that reads from
-// `PreviewState` and writes a formatted report to an `impl Write` sink.
-// None of these handlers mutate `PreviewState` — they are pure read commands.
+// Each submodule implements a colon-prefixed command that reads from (or
+// updates) `PreviewState` and writes a formatted report to an `impl Write`
+// sink.
+//
+// `reload` is the only handler here that mutates `PreviewState`; all others
+// are pure read commands.
 
 pub mod history;
 pub mod installed;
 pub mod layers;
+pub mod reload;

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -1,0 +1,387 @@
+// `:reload` REPL command — re-reads the Dockerfile, re-parses, re-runs the
+// engine, and replaces `PreviewState`.
+//
+// Error handling strategy:
+// - File read errors   → write message to err_writer, preserve old state, return Ok(())
+// - Parse errors       → write message to err_writer, preserve old state, return Ok(())
+// - Engine errors      → write message to err_writer, preserve old state, return Ok(())
+// - I/O write errors   → return Err(ReplError::InvalidArguments)
+//
+// On success, warnings from the new state are emitted to `err_writer` before
+// the confirmation message is written to `writer`.
+
+use std::io::Write;
+
+use crate::engine;
+use crate::model::state::PreviewState;
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::parser::dockerfile::parse_dockerfile;
+use crate::repl::config::ReplConfig;
+use crate::repl::error::ReplError;
+
+/// Execute the `:reload` command.
+///
+/// Re-reads the Dockerfile from `config.dockerfile_path`, re-parses it, and
+/// re-runs the engine. On success, `state` is replaced with the new state.
+/// On any error, `state` is left untouched and the error message is written to
+/// `err_writer` — the REPL loop continues normally.
+///
+/// Warnings from the new simulation are emitted to `err_writer` before the
+/// confirmation message is written to `writer`.
+pub fn execute(
+    state: &mut PreviewState,
+    config: &ReplConfig,
+    writer: &mut impl Write,
+    err_writer: &mut impl Write,
+) -> Result<(), ReplError> {
+    // Step 1: Read the Dockerfile from disk.
+    // Sanitize the path before embedding it in terminal output — the path
+    // comes from the CLI argument and could theoretically contain control bytes.
+    let content = match std::fs::read_to_string(&config.dockerfile_path) {
+        Ok(c) => c,
+        Err(e) => {
+            // Include the OS error reason so the user can distinguish "not found"
+            // from "permission denied" or other I/O failures.
+            let safe_path = sanitize_for_terminal(&config.dockerfile_path.display().to_string());
+            writeln!(
+                err_writer,
+                "demu: cannot read Dockerfile '{}': {e}",
+                safe_path
+            )
+            .map_err(|e| ReplError::InvalidArguments {
+                command: ":reload".to_string(),
+                message: e.to_string(),
+            })?;
+            return Ok(());
+        }
+    };
+
+    // Step 2: Parse the Dockerfile content into instructions.
+    let instructions = match parse_dockerfile(&content) {
+        Ok(i) => i,
+        Err(e) => {
+            let safe_msg = sanitize_for_terminal(&e.to_string());
+            writeln!(err_writer, "demu: parse error: {safe_msg}").map_err(|e| {
+                ReplError::InvalidArguments {
+                    command: ":reload".to_string(),
+                    message: e.to_string(),
+                }
+            })?;
+            return Ok(());
+        }
+    };
+
+    // Step 3: Run the engine against the parsed instructions.
+    let new_state = match engine::run(instructions, &config.context_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            let safe_msg = sanitize_for_terminal(&e.to_string());
+            writeln!(err_writer, "demu: engine error: {safe_msg}").map_err(|e| {
+                ReplError::InvalidArguments {
+                    command: ":reload".to_string(),
+                    message: e.to_string(),
+                }
+            })?;
+            return Ok(());
+        }
+    };
+
+    // Step 4a: Emit warnings from the new state to err_writer.
+    // Sanitize warning strings — they embed user-supplied Dockerfile data.
+    for w in &new_state.warnings {
+        writeln!(
+            err_writer,
+            "warning: {}",
+            sanitize_for_terminal(&w.to_string())
+        )
+        .map_err(|e| ReplError::InvalidArguments {
+            command: ":reload".to_string(),
+            message: e.to_string(),
+        })?;
+    }
+
+    // Step 4b: Count instructions processed (history entries) before replacing state.
+    let n = new_state.history.len();
+
+    // Step 4c: Replace state on success.
+    *state = new_state;
+
+    // Step 4d: Confirm success to the user.
+    writeln!(writer, "Reloaded. {n} instructions processed.").map_err(|e| {
+        ReplError::InvalidArguments {
+            command: ":reload".to_string(),
+            message: e.to_string(),
+        }
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::repl::config::ReplConfig;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::NamedTempFile;
+
+    // Helper: run execute and collect both stdout and stderr into Strings.
+    fn run_reload(
+        state: &mut PreviewState,
+        config: &ReplConfig,
+    ) -> (Result<(), ReplError>, String, String) {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = execute(state, config, &mut out, &mut err);
+        (
+            result,
+            String::from_utf8(out).expect("utf-8 stdout"),
+            String::from_utf8(err).expect("utf-8 stderr"),
+        )
+    }
+
+    // --- reload_success_replaces_state ---
+    //
+    // Writing a valid Dockerfile with ENV FOO=bar; after reload the state
+    // must contain env["FOO"] == "bar" and history.len() == 2 (FROM + ENV).
+
+    #[test]
+    fn reload_success_replaces_state() {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        write!(file, "FROM scratch\nENV FOO=bar\n").expect("write");
+
+        let config = ReplConfig::new(file.path().to_path_buf());
+        let mut state = PreviewState::default();
+
+        let (result, out, _err) = run_reload(&mut state, &config);
+        assert!(result.is_ok(), "execute must return Ok; got: {result:?}");
+        assert_eq!(
+            state.env.get("FOO").map(String::as_str),
+            Some("bar"),
+            "state.env must contain FOO=bar after reload"
+        );
+        assert!(
+            out.contains("Reloaded."),
+            "stdout must contain 'Reloaded.'; got: {out}"
+        );
+        // FROM + ENV = 2 history entries.
+        assert_eq!(
+            state.history.len(),
+            2,
+            "history must have 2 entries; got: {}",
+            state.history.len()
+        );
+    }
+
+    // --- reload_success_shows_instruction_count ---
+    //
+    // FROM scratch + WORKDIR /app + ENV X=1 = 3 instructions → "3 instructions processed".
+
+    #[test]
+    fn reload_success_shows_instruction_count() {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        write!(file, "FROM scratch\nWORKDIR /app\nENV X=1\n").expect("write");
+
+        let config = ReplConfig::new(file.path().to_path_buf());
+        let mut state = PreviewState::default();
+
+        let (result, out, _err) = run_reload(&mut state, &config);
+        assert!(result.is_ok());
+        assert!(
+            out.contains("3 instructions processed"),
+            "stdout must contain '3 instructions processed'; got: {out}"
+        );
+    }
+
+    // --- reload_file_not_found_keeps_old_state ---
+    //
+    // Config points to a non-existent path. Old state (cwd=/original) must
+    // be preserved. stderr must contain "Dockerfile not found".
+
+    #[test]
+    fn reload_file_not_found_keeps_old_state() {
+        // Drop a NamedTempFile immediately so the path is guaranteed not to exist.
+        let gone_path = {
+            let tmp = NamedTempFile::new().expect("tempfile");
+            tmp.path().to_path_buf()
+            // tmp is dropped here — file is deleted
+        };
+        let config = ReplConfig::new(gone_path);
+
+        let mut state = PreviewState::default();
+        state.cwd = PathBuf::from("/original");
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(
+            result.is_ok(),
+            "execute must return Ok even on file-not-found; got: {result:?}"
+        );
+        assert_eq!(
+            state.cwd,
+            PathBuf::from("/original"),
+            "state.cwd must remain /original; got: {}",
+            state.cwd.display()
+        );
+        assert!(
+            err.contains("cannot read Dockerfile"),
+            "stderr must mention read failure; got: {err}"
+        );
+    }
+
+    // --- reload_parse_error_keeps_old_state ---
+    //
+    // File exists but contains invalid Dockerfile syntax. Old state is preserved,
+    // stderr contains "parse error".
+    //
+    // "FROM" with no image triggers ParseError::InvalidInstruction because the
+    // parser expects at least one token after the FROM keyword. Unknown keywords
+    // are turned into Instruction::Unknown (not errors), so we use a known keyword
+    // with missing required arguments to guarantee a real parse error.
+
+    #[test]
+    fn reload_parse_error_keeps_old_state() {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        // "FROM" with no image name — triggers ParseError::InvalidInstruction.
+        write!(file, "FROM\n").expect("write");
+
+        let config = ReplConfig::new(file.path().to_path_buf());
+        let mut state = PreviewState::default();
+        state.cwd = PathBuf::from("/original");
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(
+            result.is_ok(),
+            "execute must return Ok even on parse error; got: {result:?}"
+        );
+        assert_eq!(
+            state.cwd,
+            PathBuf::from("/original"),
+            "state must be preserved on parse error"
+        );
+        assert!(
+            err.contains("parse error"),
+            "stderr must contain 'parse error'; got: {err}"
+        );
+    }
+
+    // --- reload_after_file_change_picks_up_new_content ---
+    //
+    // Reload picks up content changes: first load sees ENV A=first; after
+    // overwriting the file, second reload sees ENV B=second and A is gone.
+
+    #[test]
+    fn reload_after_file_change_picks_up_new_content() {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        // v1: ENV A=first
+        write!(file, "FROM scratch\nENV A=first\n").expect("write v1");
+
+        let df_path = file.path().to_path_buf();
+        let config = ReplConfig::new(df_path.clone());
+        let mut state = PreviewState::default();
+
+        // First reload — should see A=first.
+        let (r1, _, _) = run_reload(&mut state, &config);
+        assert!(r1.is_ok());
+        assert_eq!(
+            state.env.get("A").map(String::as_str),
+            Some("first"),
+            "after v1 reload, env[A] must be 'first'"
+        );
+
+        // Overwrite the file with v2 — ENV B=second (A is gone).
+        let mut f2 = std::fs::File::create(&df_path).expect("create v2");
+        write!(f2, "FROM scratch\nENV B=second\n").expect("write v2");
+
+        // Second reload — should see B=second and A gone.
+        let (r2, _, _) = run_reload(&mut state, &config);
+        assert!(r2.is_ok());
+        assert!(
+            state.env.contains_key("B"),
+            "after v2 reload, env must contain B"
+        );
+        assert!(
+            !state.env.contains_key("A"),
+            "after v2 reload, env must not contain A"
+        );
+    }
+
+    // --- reload_engine_error_keeps_old_state ---
+    //
+    // Trigger EngineError::Io by making a COPY source path unreadable (not just
+    // absent — a missing source becomes Warning::MissingCopySource, not an error).
+    // We lock a directory with mode 000 so fs::metadata on its contents returns
+    // PermissionDenied, which is not NotFound and therefore triggers EngineError::Io.
+    //
+    // Only runs on Unix because Windows file permissions work differently.
+
+    #[test]
+    #[cfg(unix)]
+    fn reload_engine_error_keeps_old_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let ctx_dir = tempfile::TempDir::new().expect("tempdir");
+
+        // Create a locked sub-directory with a file inside it.
+        let locked = ctx_dir.path().join("locked");
+        std::fs::create_dir(&locked).expect("create locked dir");
+        std::fs::write(locked.join("src.txt"), b"data").expect("write src");
+        // Remove all permissions — fs::metadata on contents returns PermissionDenied.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("chmod 000");
+
+        // Dockerfile COPYs from inside the locked directory.
+        let mut df_file = NamedTempFile::new().expect("tempfile");
+        write!(df_file, "FROM scratch\nCOPY locked/src.txt /dst\n").expect("write df");
+
+        // Build config pointing at the Dockerfile with the temp dir as context.
+        let config =
+            ReplConfig::with_context(df_file.path().to_path_buf(), ctx_dir.path().to_path_buf());
+
+        let mut state = PreviewState::default();
+        state.cwd = PathBuf::from("/original");
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+
+        // Restore permissions before any assertion so TempDir can clean up on failure.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755))
+            .expect("restore permissions");
+
+        assert!(
+            result.is_ok(),
+            "execute must return Ok even on engine error; got: {result:?}"
+        );
+        assert_eq!(
+            state.cwd,
+            PathBuf::from("/original"),
+            "state must be preserved on engine error; got: {}",
+            state.cwd.display()
+        );
+        assert!(
+            err.contains("engine error"),
+            "stderr must contain 'engine error'; got: {err}"
+        );
+    }
+
+    // --- reload_warnings_emitted_to_err_writer ---
+    //
+    // FROM scratch always emits Warning::EmptyBaseImage. After reload, stderr
+    // must contain "warning".
+
+    #[test]
+    fn reload_warnings_emitted_to_err_writer() {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        // FROM scratch always triggers EmptyBaseImage warning.
+        write!(file, "FROM scratch\n").expect("write");
+
+        let config = ReplConfig::new(file.path().to_path_buf());
+        let mut state = PreviewState::default();
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(result.is_ok());
+        assert!(
+            err.contains("warning"),
+            "stderr must contain 'warning' from EmptyBaseImage; got: {err}"
+        );
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -6,6 +6,7 @@
 // and the `exit` command).
 
 pub mod commands;
+pub mod config;
 pub mod custom;
 pub mod error;
 pub mod parse;
@@ -25,7 +26,8 @@ use rustyline::DefaultEditor;
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
 use crate::repl::commands::{apt, cat, cd, env_cmd, find, help, ls, pip, pwd, which};
-use crate::repl::custom::{history, installed, layers};
+use crate::repl::config::ReplConfig;
+use crate::repl::custom::{history, installed, layers, reload};
 use crate::repl::error::ReplError;
 use crate::repl::parse::{parse_input, ParsedCommand};
 
@@ -34,11 +36,13 @@ use crate::repl::parse::{parse_input, ParsedCommand};
 /// The REPL:
 /// - Displays a dynamic prompt showing the current working directory.
 /// - Parses each input line into a [`ParsedCommand`].
-/// - Dispatches to the appropriate command handler.
+/// - Handles `:reload` inline before calling `dispatch` (because reload needs
+///   access to `config` and both stdout and stderr writers simultaneously).
+/// - Dispatches all other commands to [`dispatch`].
 /// - Prints errors from handlers as compact terminal messages (non-fatal).
 /// - Exits gracefully on Ctrl-D, `exit`, or `quit`.
 /// - Continues on Ctrl-C (prints a hint on how to exit).
-pub fn run_repl(state: &mut PreviewState) -> anyhow::Result<()> {
+pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result<()> {
     let mut editor = DefaultEditor::new()?;
     let stdout = io::stdout();
 
@@ -58,6 +62,19 @@ pub fn run_repl(state: &mut PreviewState) -> anyhow::Result<()> {
 
                 let cmd = parse_input(&line);
                 let mut out = stdout.lock();
+
+                // `:reload` is handled before dispatch because it requires
+                // both a stdout writer and a stderr writer simultaneously, and
+                // it also needs the session-level `config`. It is intentionally
+                // NOT part of `dispatch` — see the comment in `dispatch` below.
+                if cmd == ParsedCommand::Reload {
+                    let mut err_out = io::stderr();
+                    if let Err(e) = reload::execute(state, config, &mut out, &mut err_out) {
+                        let safe = sanitize_for_terminal(&e.to_string());
+                        eprintln!("{safe}");
+                    }
+                    continue;
+                }
 
                 match dispatch(state, cmd, &mut out) {
                     // `exit` / `quit` — terminate the loop cleanly.
@@ -101,6 +118,11 @@ pub fn run_repl(state: &mut PreviewState) -> anyhow::Result<()> {
 ///
 /// Returns `Ok(true)` normally or `Ok(false)` when the command signals exit.
 /// The caller is responsible for exiting the loop on `Exit`.
+///
+/// Note: `ParsedCommand::Reload` is intentionally NOT handled here. It is
+/// intercepted in `run_repl` before this function is called, because reload
+/// needs access to both stdout and stderr writers as well as the session-level
+/// `ReplConfig`. This design avoids threading config through dispatch.
 pub fn dispatch(
     state: &mut PreviewState,
     cmd: ParsedCommand,
@@ -154,6 +176,11 @@ pub fn dispatch(
         }
         ParsedCommand::Unknown { input } => {
             return Err(ReplError::UnknownCommand { input });
+        }
+        // Reload is intercepted in `run_repl` before `dispatch` is called.
+        // Reaching this arm indicates a programming error in the REPL loop.
+        ParsedCommand::Reload => {
+            unreachable!(":reload must be handled in run_repl before dispatch is called");
         }
     }
 
@@ -555,6 +582,18 @@ mod tests {
             matches!(result, Err(ReplError::UnknownCommand { .. })),
             "bare 'pip' must return UnknownCommand; got: {result:?}"
         );
+    }
+
+    // --- :reload parse layer ---
+    //
+    // `:reload` is intercepted in `run_repl` before `dispatch` is called, so
+    // `dispatch` will never see it in normal operation (it panics via
+    // `unreachable!` if it does). The parse-layer test below is sufficient to
+    // confirm that the parser recognises the command correctly.
+
+    #[test]
+    fn reload_is_recognized_by_parse_input() {
+        assert_eq!(parse_input(":reload"), ParsedCommand::Reload);
     }
 
     // --- :history dispatch ---

--- a/src/repl/parse.rs
+++ b/src/repl/parse.rs
@@ -56,6 +56,8 @@ pub enum ParsedCommand {
     },
     /// `pip list` — list simulated pip packages.
     PipList,
+    /// `:reload` — re-read and re-process the Dockerfile.
+    Reload,
     /// The input was empty or only whitespace.
     Empty,
     /// The input did not match any known command.
@@ -101,6 +103,7 @@ pub fn parse_input(line: &str) -> ParsedCommand {
         ":layers" => ParsedCommand::Layers,
         ":history" => ParsedCommand::History,
         ":installed" => ParsedCommand::Installed,
+        ":reload" => ParsedCommand::Reload,
         _ => ParsedCommand::Unknown {
             input: trimmed.to_string(),
         },
@@ -748,6 +751,29 @@ mod tests {
             parse_input("WHICH curl"),
             ParsedCommand::Unknown {
                 input: "WHICH curl".to_string()
+            }
+        );
+    }
+
+    // --- :reload ---
+
+    #[test]
+    fn reload_bare_returns_reload() {
+        assert_eq!(parse_input(":reload"), ParsedCommand::Reload);
+    }
+
+    #[test]
+    fn reload_with_trailing_whitespace_returns_reload() {
+        assert_eq!(parse_input(":reload  "), ParsedCommand::Reload);
+    }
+
+    #[test]
+    fn reload_uppercase_is_unknown() {
+        // Custom commands are case-sensitive — :RELOAD is not :reload.
+        assert_eq!(
+            parse_input(":RELOAD"),
+            ParsedCommand::Unknown {
+                input: ":RELOAD".to_string()
             }
         );
     }


### PR DESCRIPTION
## Summary

- Adds `:reload` to re-read and re-process the Dockerfile without restarting `demu`
- Old state preserved on any failure (file not found, parse error, engine error)
- Confirmation: `Reloaded. <N> instructions processed.`
- New `ReplConfig` struct separates session metadata from simulation output

## What changed

| File | Change |
|------|--------|
| `src/repl/config.rs` | NEW — `ReplConfig` with `new(path)` and `with_context(path, dir)` |
| `src/repl/custom/reload.rs` | NEW — `:reload` handler with 7 unit tests |
| `src/repl/parse.rs` | Added `Reload` variant + parse arm |
| `src/repl/mod.rs` | `run_repl` accepts `&ReplConfig`; reload intercepted before dispatch |
| `src/main.rs` | Construct `ReplConfig` and pass to `run_repl` |
| `src/repl/commands/help.rs` | Added `:reload` to help text |

## Test plan

- [ ] 480 tests passing
- [ ] `cargo fmt -- --check` clean
- [ ] `cargo clippy -- -D warnings` clean
- [ ] All error paths preserve old state (assert `state.cwd` unchanged)
- [ ] Engine error path covered via unix chmod 000 test
- [ ] Code review: no CRITICAL; HIGH issues resolved (OS error included in message, dispatch uses `unreachable!`, main.rs clones removed)
- [ ] Security review: PASS — error strings sanitized; path display sanitized
- [ ] QA review: NEEDS WORK items resolved — engine error test added, ReplConfig refactored to single-arg `new`
- [ ] Architect review: `ReplConfig::new` now derives `context_dir` from parent; `with_context` escape hatch added

Closes #24