### PR TITLE
refactor: extract io_err_mapper helper (#32)

### DIFF
--- a/src/repl/commands/apt.rs
+++ b/src/repl/commands/apt.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::repl::error::ReplError;
+use crate::repl::error::{io_err_mapper, ReplError};
 
 /// Execute the `apt list [--installed]` command.
 ///
@@ -35,29 +35,26 @@ pub fn execute(
     writer: &mut impl Write,
 ) -> Result<(), ReplError> {
     // Map I/O errors into ReplError so callers see a consistent error type.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
-        command: "apt".to_string(),
-        message: e.to_string(),
-    };
+    let io_err = io_err_mapper("apt");
 
     if !installed {
         // No --installed flag — show usage hint, not the full listing.
-        writeln!(writer, "Usage: apt list --installed").map_err(io_err)?;
+        writeln!(writer, "Usage: apt list --installed").map_err(&io_err)?;
         return Ok(());
     }
 
     // --installed flag given — produce the Debian-style listing.
-    writeln!(writer, "Listing...").map_err(io_err)?;
+    writeln!(writer, "Listing...").map_err(&io_err)?;
 
     let packages = state.installed.list("apt");
     if packages.is_empty() {
-        writeln!(writer, "(no packages recorded)").map_err(io_err)?;
+        writeln!(writer, "(no packages recorded)").map_err(&io_err)?;
     } else {
         for pkg in &packages {
             // Sanitize each package name before writing; package names come
             // from engine-processed Dockerfile text which may contain escape bytes.
             let safe_pkg = sanitize_for_terminal(pkg);
-            writeln!(writer, "{safe_pkg}/simulated [installed,simulated]").map_err(io_err)?;
+            writeln!(writer, "{safe_pkg}/simulated [installed,simulated]").map_err(&io_err)?;
         }
     }
 

--- a/src/repl/commands/pip.rs
+++ b/src/repl/commands/pip.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::repl::error::ReplError;
+use crate::repl::error::{io_err_mapper, ReplError};
 
 /// Column width for the Package name field.
 ///
@@ -32,21 +32,18 @@ const PKG_COL_WIDTH: usize = 10;
 /// Package names are sanitized before output to prevent terminal escape injection.
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into ReplError so callers see a consistent error type.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
-        command: "pip".to_string(),
-        message: e.to_string(),
-    };
+    let io_err = io_err_mapper("pip");
 
     // Always write the header and separator, even for an empty registry.
-    writeln!(writer, "Package    Version").map_err(io_err)?;
-    writeln!(writer, "---------- -------").map_err(io_err)?;
+    writeln!(writer, "Package    Version").map_err(&io_err)?;
+    writeln!(writer, "---------- -------").map_err(&io_err)?;
 
     let packages = state.installed.list("pip");
     for pkg in &packages {
         // Sanitize each package name before writing; package names originate from
         // engine-processed Dockerfile text which may contain escape bytes.
         let safe_pkg = sanitize_for_terminal(pkg);
-        writeln!(writer, "{safe_pkg:<PKG_COL_WIDTH$} (simulated)").map_err(io_err)?;
+        writeln!(writer, "{safe_pkg:<PKG_COL_WIDTH$} (simulated)").map_err(&io_err)?;
     }
 
     Ok(())

--- a/src/repl/commands/which.rs
+++ b/src/repl/commands/which.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::repl::error::ReplError;
+use crate::repl::error::{io_err_mapper, ReplError};
 
 /// Execute the `which <cmd>` command.
 ///
@@ -51,10 +51,7 @@ pub fn execute(state: &PreviewState, cmd: &str, writer: &mut impl Write) -> Resu
         })?;
 
     let path = format!("{prefix}/{safe_cmd}");
-    writeln!(writer, "{path}").map_err(|e| ReplError::InvalidArguments {
-        command: "which".to_string(),
-        message: e.to_string(),
-    })
+    writeln!(writer, "{path}").map_err(io_err_mapper("which"))
 }
 
 #[cfg(test)]

--- a/src/repl/custom/installed.rs
+++ b/src/repl/custom/installed.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::repl::error::ReplError;
+use crate::repl::error::{io_err_mapper, ReplError};
 
 /// Canonical display order for package managers.
 ///
@@ -39,10 +39,7 @@ const MANAGER_ORDER: &[&str] = &["apt", "pip", "npm", "apk", "go"];
 /// [`ReplError::InvalidArguments`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a uniform ReplError.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
-        command: ":installed".to_string(),
-        message: e.to_string(),
-    };
+    let io_err = io_err_mapper(":installed");
 
     // Collect non-empty managers in canonical order.
     let mut any_printed = false;
@@ -57,12 +54,12 @@ pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), Repl
         // user-supplied and may in theory contain control characters.
         let sanitized: Vec<String> = packages.iter().map(|p| sanitize_for_terminal(p)).collect();
 
-        writeln!(writer, "{}: {}", manager, sanitized.join(", ")).map_err(io_err)?;
+        writeln!(writer, "{}: {}", manager, sanitized.join(", ")).map_err(&io_err)?;
         any_printed = true;
     }
 
     if !any_printed {
-        writeln!(writer, "No packages recorded.").map_err(io_err)?;
+        writeln!(writer, "No packages recorded.").map_err(&io_err)?;
     }
 
     Ok(())

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -17,7 +17,7 @@ use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
 use crate::parser::dockerfile::parse_dockerfile;
 use crate::repl::config::ReplConfig;
-use crate::repl::error::ReplError;
+use crate::repl::error::{io_err_mapper, ReplError};
 
 /// Execute the `:reload` command.
 ///
@@ -48,10 +48,7 @@ pub fn execute(
                 "demu: cannot read Dockerfile '{}': {e}",
                 safe_path
             )
-            .map_err(|e| ReplError::InvalidArguments {
-                command: ":reload".to_string(),
-                message: e.to_string(),
-            })?;
+            .map_err(io_err_mapper(":reload"))?;
             return Ok(());
         }
     };
@@ -61,12 +58,8 @@ pub fn execute(
         Ok(i) => i,
         Err(e) => {
             let safe_msg = sanitize_for_terminal(&e.to_string());
-            writeln!(err_writer, "demu: parse error: {safe_msg}").map_err(|e| {
-                ReplError::InvalidArguments {
-                    command: ":reload".to_string(),
-                    message: e.to_string(),
-                }
-            })?;
+            writeln!(err_writer, "demu: parse error: {safe_msg}")
+                .map_err(io_err_mapper(":reload"))?;
             return Ok(());
         }
     };
@@ -76,12 +69,8 @@ pub fn execute(
         Ok(s) => s,
         Err(e) => {
             let safe_msg = sanitize_for_terminal(&e.to_string());
-            writeln!(err_writer, "demu: engine error: {safe_msg}").map_err(|e| {
-                ReplError::InvalidArguments {
-                    command: ":reload".to_string(),
-                    message: e.to_string(),
-                }
-            })?;
+            writeln!(err_writer, "demu: engine error: {safe_msg}")
+                .map_err(io_err_mapper(":reload"))?;
             return Ok(());
         }
     };
@@ -94,10 +83,7 @@ pub fn execute(
             "warning: {}",
             sanitize_for_terminal(&w.to_string())
         )
-        .map_err(|e| ReplError::InvalidArguments {
-            command: ":reload".to_string(),
-            message: e.to_string(),
-        })?;
+        .map_err(io_err_mapper(":reload"))?;
     }
 
     // Step 4b: Count instructions processed (history entries) before replacing state.
@@ -107,12 +93,7 @@ pub fn execute(
     *state = new_state;
 
     // Step 4d: Confirm success to the user.
-    writeln!(writer, "Reloaded. {n} instructions processed.").map_err(|e| {
-        ReplError::InvalidArguments {
-            command: ":reload".to_string(),
-            message: e.to_string(),
-        }
-    })?;
+    writeln!(writer, "Reloaded. {n} instructions processed.").map_err(io_err_mapper(":reload"))?;
 
     Ok(())
 }

--- a/src/repl/error.rs
+++ b/src/repl/error.rs
@@ -38,10 +38,35 @@ pub enum ReplError {
     UnknownCommand { input: String },
 }
 
+/// Returns a closure that maps a [`std::io::Error`] into
+/// [`ReplError::InvalidArguments`] for the given command name.
+///
+/// This is a shared helper so that command handlers do not each have to
+/// define the same 3-line inline closure. Use it wherever a `writeln!` or
+/// similar I/O operation needs to map its error into `ReplError`:
+///
+/// ```ignore
+/// use crate::repl::error::io_err_mapper;
+///
+/// let io_err = io_err_mapper("apt");
+/// writeln!(writer, "...").map_err(&io_err)?;
+/// ```
+///
+/// The returned closure is `'static` — it owns an allocated `String` copy of
+/// `command` and has no lifetime dependency on the original `&str`.
+pub fn io_err_mapper(command: &str) -> impl Fn(std::io::Error) -> ReplError {
+    let command = command.to_owned();
+    move |e| ReplError::InvalidArguments {
+        command: command.clone(),
+        message: e.to_string(),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::io;
     use std::path::PathBuf;
 
     // --- PathNotFound ---
@@ -126,5 +151,60 @@ mod tests {
         };
         let debug = format!("{err:?}");
         assert!(!debug.is_empty());
+    }
+
+    // --- io_err_mapper ---
+
+    /// `io_err_mapper` must produce `ReplError::InvalidArguments` with the
+    /// exact command name and the I/O error message string.
+    #[test]
+    fn io_err_mapper_produces_invalid_arguments_with_command_name() {
+        let mapper = io_err_mapper("test-cmd");
+        let raw_err = io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe");
+        let err = mapper(raw_err);
+        assert_eq!(
+            err,
+            ReplError::InvalidArguments {
+                command: "test-cmd".to_string(),
+                message: "broken pipe".to_string(),
+            },
+            "io_err_mapper must wrap the io::Error into InvalidArguments; got: {err:?}"
+        );
+    }
+
+    /// `io_err_mapper` must be callable multiple times (the closure is `Fn`, not `FnOnce`).
+    #[test]
+    fn io_err_mapper_is_callable_multiple_times() {
+        let mapper = io_err_mapper("multi");
+        let e1 = mapper(io::Error::new(io::ErrorKind::Other, "first"));
+        let e2 = mapper(io::Error::new(io::ErrorKind::Other, "second"));
+        assert_eq!(
+            e1,
+            ReplError::InvalidArguments {
+                command: "multi".to_string(),
+                message: "first".to_string(),
+            }
+        );
+        assert_eq!(
+            e2,
+            ReplError::InvalidArguments {
+                command: "multi".to_string(),
+                message: "second".to_string(),
+            }
+        );
+    }
+
+    /// `io_err_mapper` must preserve the command name exactly (no truncation, no transforms).
+    #[test]
+    fn io_err_mapper_preserves_command_name_with_colon_prefix() {
+        let err = io_err_mapper(":reload")(io::Error::new(io::ErrorKind::Other, "oops"));
+        assert_eq!(
+            err,
+            ReplError::InvalidArguments {
+                command: ":reload".to_string(),
+                message: "oops".to_string(),
+            },
+            "colon-prefixed command name must be preserved; got: {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Extract shared `io_err_mapper(command: &str) -> impl Fn(io::Error) -> ReplError` helper to `src/repl/error.rs`
- Removes repeated inline closure definition from `apt.rs`, `pip.rs`, `which.rs`, `installed.rs`, `reload.rs`
- Returned closure is `'static` — eagerly converts `command` to `String` before capture, no lifetime annotation

## Test plan

- [ ] 502 tests pass, 0 failed
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] 3 new unit tests in `error.rs`: correct variant, callable multiple times, colon-prefix preserved

Closes #32