### PR TITLE
fix: sanitize env var keys and values before terminal output (#33)

### DIFF
--- a/src/repl/commands/env_cmd.rs
+++ b/src/repl/commands/env_cmd.rs
@@ -2,23 +2,36 @@
 //
 // Iterates `state.env` (a `BTreeMap` so keys are already sorted lexicographically)
 // and prints each entry in `KEY=value` format, one per line.
+//
+// Both key and value are sanitized via `sanitize_for_terminal` before output
+// to prevent terminal escape-sequence injection from user-controlled Dockerfile
+// `ENV` instructions.
 
 use std::io::Write;
 
 use crate::model::state::PreviewState;
-use crate::repl::error::ReplError;
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::error::{io_err_mapper, ReplError};
 
 /// Execute the `env` command.
 ///
 /// Writes each environment variable as `KEY=value\n` to `writer`.
 /// Keys are emitted in sorted order because `PreviewState.env` is a `BTreeMap`.
 /// If the environment is empty, nothing is written.
+///
+/// Both key and value are passed through `sanitize_for_terminal` before
+/// writing. This prevents ANSI escape injection when Dockerfile `ENV`
+/// instructions contain control characters.
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
+    // Map I/O errors into a uniform ReplError using the shared helper.
+    let io_err = io_err_mapper("env");
+
     for (key, value) in &state.env {
-        writeln!(writer, "{key}={value}").map_err(|e| ReplError::InvalidArguments {
-            command: "env".to_string(),
-            message: e.to_string(),
-        })?;
+        // Sanitize both key and value: ENV values come from user-controlled
+        // Dockerfile text and may contain terminal control sequences.
+        let safe_key = sanitize_for_terminal(key);
+        let safe_value = sanitize_for_terminal(value);
+        writeln!(writer, "{safe_key}={safe_value}").map_err(&io_err)?;
     }
     Ok(())
 }
@@ -109,5 +122,72 @@ mod tests {
         let state = PreviewState::default();
         let mut buf = Vec::new();
         assert!(execute(&state, &mut buf).is_ok());
+    }
+
+    // --- Sanitization: key ---
+
+    /// A key containing an ANSI escape sequence must have the control bytes
+    /// stripped before the line is written to the terminal output buffer.
+    /// The raw ESC byte (0x1B) must not appear in the output, but the
+    /// non-control portion of the key must still be present.
+    #[test]
+    fn env_sanitizes_embedded_control_characters_in_key() {
+        let mut state = PreviewState::default();
+        // Key contains an ANSI erase-display sequence and an embedded newline.
+        let poisoned_key = "BAD_KEY\x1b[2J\nEXTRA".to_string();
+        state.env.insert(poisoned_key, "safe_value".to_string());
+        let mut buf = Vec::new();
+        execute(&state, &mut buf).expect("should succeed");
+        // ESC byte (0x1B) must be stripped.
+        assert!(
+            !buf.contains(&0x1B),
+            "ESC must be stripped from key output; raw bytes: {:?}",
+            buf
+        );
+        // Embedded newline (0x0A) that was part of the key must also be stripped —
+        // only the trailing newline added by writeln! should remain.
+        let out = String::from_utf8(buf).expect("utf-8");
+        // The safe portion of the key must survive.
+        assert!(
+            out.contains("BAD_KEY"),
+            "base key text must survive sanitization; got:\n{out}"
+        );
+        // The raw escape sequence characters must not appear literally.
+        assert!(
+            !out.contains("\x1b"),
+            "literal ESC must not appear in output; got:\n{out}"
+        );
+    }
+
+    // --- Sanitization: value ---
+
+    /// A value containing an ANSI escape sequence must have the control bytes
+    /// stripped before the line is written to the terminal output buffer.
+    #[test]
+    fn env_sanitizes_embedded_control_characters_in_value() {
+        let mut state = PreviewState::default();
+        // Value contains an ANSI erase-display sequence.
+        let poisoned_value = "safe\x1b[2Jvalue".to_string();
+        state.env.insert("CLEAN_KEY".to_string(), poisoned_value);
+        let mut buf = Vec::new();
+        execute(&state, &mut buf).expect("should succeed");
+        // ESC byte (0x1B) must be stripped from output.
+        assert!(
+            !buf.contains(&0x1B),
+            "ESC must be stripped from value output; raw bytes: {:?}",
+            buf
+        );
+        let out = String::from_utf8(buf).expect("utf-8");
+        // The safe portions of the value must survive.
+        assert!(
+            out.contains("safe"),
+            "leading safe text must survive sanitization; got:\n{out}"
+        );
+        assert!(
+            out.contains("value"),
+            "trailing safe text must survive sanitization; got:\n{out}"
+        );
+        // Key must also appear unchanged.
+        assert!(out.contains("CLEAN_KEY"), "key must appear; got:\n{out}");
     }
 }


### PR DESCRIPTION
## Summary

- Apply `sanitize_for_terminal` to both key and value in `env_cmd::execute` before writing to terminal
- Fixes the only REPL command that was writing user-controlled data (from Dockerfile ENV instructions) without sanitization
- Also replaces the inline `io_err` closure with `io_err_mapper("env")` from #32

## Test plan

- [ ] 504 tests pass, 0 failed
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] New test: key with embedded `\x1b[2J` — ESC byte stripped from output
- [ ] New test: value with embedded control characters — stripped from output

Closes #33