### PR TITLE
feat: Compose YAML parser (#48)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,8 @@ dependencies = [
  "anyhow",
  "clap",
  "rustyline",
+ "serde",
+ "serde_yaml",
  "tempfile",
  "thiserror",
 ]
@@ -409,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -454,6 +463,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -535,6 +557,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ clap = { version = "4", features = ["derive"] }
 rustyline = "14"
 thiserror = "2"
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/model/compose.rs
+++ b/src/model/compose.rs
@@ -1,0 +1,121 @@
+//! Domain model types for Docker Compose files.
+//!
+//! These types represent the clean, validated view of a `docker-compose.yml`
+//! after parsing.  They intentionally do **not** derive `Deserialize` — that
+//! concern lives in the parser module where intermediate raw types are used
+//! to handle Compose's many dual-form fields (string *or* map, list *or* dict,
+//! etc.).
+//!
+//! # Module layout
+//!
+//! | Type | Purpose |
+//! |------|---------|
+//! | `ComposeFile` | Top-level container: services + named-volume declarations |
+//! | `Service` | One `docker-compose.yml` service definition |
+//! | `BuildConfig` | Build context and Dockerfile path |
+//! | `EnvEntry` | A single environment variable (key=value or bare key) |
+//! | `VolumeSpec` | A per-service volume mount (bind, named, or anonymous) |
+//! | `VolumeDefinition` | A top-level named volume declaration |
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// The top-level structure of a parsed `docker-compose.yml`.
+///
+/// `services` is always present (parsing fails if the key is missing).
+/// `volumes` may be empty when no top-level named volumes are declared.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComposeFile {
+    /// All service definitions keyed by service name.
+    pub services: BTreeMap<String, Service>,
+    /// Top-level named volume declarations keyed by volume name.
+    pub volumes: BTreeMap<String, VolumeDefinition>,
+}
+
+/// A single service definition inside a Compose file.
+///
+/// Fields mirror the most commonly used Compose keys.  Unknown keys in the
+/// source YAML are silently ignored — this matches Docker's own tolerant
+/// parsing behaviour and keeps the preview useful even for complex files.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Service {
+    /// The service name (taken from the YAML map key, not a field inside the
+    /// service map).
+    pub name: String,
+    /// Build configuration when the service is built from a local context.
+    pub build: Option<BuildConfig>,
+    /// Pre-built image reference (e.g. `"postgres:15"`).
+    pub image: Option<String>,
+    /// Environment variables injected into the container.
+    pub environment: Vec<EnvEntry>,
+    /// Paths to env-file(s) whose contents are injected as environment
+    /// variables.
+    pub env_file: Vec<PathBuf>,
+    /// Volume mounts for this service.
+    pub volumes: Vec<VolumeSpec>,
+    /// Working directory override inside the container.
+    pub working_dir: Option<PathBuf>,
+    /// Names of services that must start before this one.
+    pub depends_on: Vec<String>,
+    /// Port mappings (kept as raw strings — format varies widely and we only
+    /// need them for informational display, not actual binding).
+    pub ports: Vec<String>,
+}
+
+/// Build configuration for a service that is built from local source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BuildConfig {
+    /// The build context directory (e.g. `"."` or `"./services/api"`).
+    pub context: PathBuf,
+    /// Path to the Dockerfile relative to `context`.  Defaults to
+    /// `"Dockerfile"` when only a short-form string is given.
+    pub dockerfile: PathBuf,
+}
+
+/// A single environment variable entry.
+///
+/// Compose supports two forms:
+/// - `KEY=value` or dict `{KEY: value}` → [`EnvEntry::KeyValue`]
+/// - bare `KEY` (value taken from the host environment at runtime) →
+///   [`EnvEntry::KeyOnly`]
+#[derive(Debug, Clone, PartialEq)]
+pub enum EnvEntry {
+    /// A fully-specified `KEY=value` pair.
+    KeyValue { key: String, value: String },
+    /// A key with no value — the runtime inherits it from the host environment.
+    KeyOnly { key: String },
+}
+
+/// A volume mount specification for a service.
+///
+/// Compose supports three variants:
+/// - **Bind mount** — host path mapped into the container
+/// - **Named volume** — a Docker-managed named volume
+/// - **Anonymous** — no source, just a container path
+#[derive(Debug, Clone, PartialEq)]
+pub enum VolumeSpec {
+    /// A bind mount from a host path into the container.
+    Bind {
+        host_path: PathBuf,
+        container_path: PathBuf,
+        read_only: bool,
+    },
+    /// A named volume (managed by Docker).
+    Named {
+        volume_name: String,
+        container_path: PathBuf,
+        read_only: bool,
+    },
+    /// An anonymous volume with only a container path.
+    Anonymous { container_path: PathBuf },
+}
+
+/// A top-level named volume declaration.
+///
+/// Currently only tracks whether the volume is declared as `external` (i.e.
+/// it must already exist and Compose should not attempt to create it).
+#[derive(Debug, Clone, PartialEq)]
+pub struct VolumeDefinition {
+    /// `true` when `external: true` is set in the volume declaration.
+    pub external: bool,
+}

--- a/src/model/compose.rs
+++ b/src/model/compose.rs
@@ -50,6 +50,11 @@ pub struct Service {
     pub environment: Vec<EnvEntry>,
     /// Paths to env-file(s) whose contents are injected as environment
     /// variables.
+    ///
+    /// # Security note
+    /// Stored verbatim from the YAML — may contain `..` components. Callers
+    /// must validate these paths against the project root before reading them
+    /// from the host filesystem.
     pub env_file: Vec<PathBuf>,
     /// Volume mounts for this service.
     pub volumes: Vec<VolumeSpec>,
@@ -66,9 +71,19 @@ pub struct Service {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BuildConfig {
     /// The build context directory (e.g. `"."` or `"./services/api"`).
+    ///
+    /// # Security note
+    /// Stored verbatim from the YAML — may contain `..` components. Callers
+    /// that use this path for host filesystem access **must** canonicalize it
+    /// and verify it does not escape the declared project root before opening
+    /// any file.
     pub context: PathBuf,
     /// Path to the Dockerfile relative to `context`.  Defaults to
     /// `"Dockerfile"` when only a short-form string is given.
+    ///
+    /// # Security note
+    /// Stored verbatim from the YAML. Same path-containment requirement as
+    /// `context` applies.
     pub dockerfile: PathBuf,
 }
 
@@ -95,6 +110,12 @@ pub enum EnvEntry {
 #[derive(Debug, Clone, PartialEq)]
 pub enum VolumeSpec {
     /// A bind mount from a host path into the container.
+    ///
+    /// # Security note
+    /// `host_path` is stored verbatim from the YAML and may contain `..`
+    /// components. It is used only as display/shadow metadata in the preview
+    /// — it must **never** be opened on the host filesystem without first
+    /// canonicalizing and confirming it does not escape the project root.
     Bind {
         host_path: PathBuf,
         container_path: PathBuf,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,13 +13,16 @@
 //! | `instruction` | `CopySource`, `Instruction` enum |
 //! | `fs` | `FileNode`, `DirNode`, `SymlinkNode`, `FsNode`, `VirtualFs` |
 //! | `state` | `InstalledRegistry`, `HistoryEntry`, `LayerSummary`, `PreviewState` |
+//! | `compose` | `ComposeFile`, `Service`, `BuildConfig`, `EnvEntry`, `VolumeSpec`, `VolumeDefinition` |
 
+pub mod compose;
 pub mod fs;
 pub mod instruction;
 pub mod provenance;
 pub mod state;
 pub mod warning;
 
+pub use compose::{BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition, VolumeSpec};
 pub use fs::{FsNode, VirtualFs};
 pub use instruction::Instruction;
 pub use provenance::Provenance;

--- a/src/parser/compose.rs
+++ b/src/parser/compose.rs
@@ -258,9 +258,13 @@ fn yaml_value_to_string(v: serde_yaml::Value) -> String {
         serde_yaml::Value::Number(n) => n.to_string(),
         serde_yaml::Value::Bool(b) => b.to_string(),
         serde_yaml::Value::Null => String::new(),
-        // Nested sequences/mappings are stringified as YAML — unusual but safe.
+        // Nested sequences/mappings are stringified as YAML — unusual but valid.
+        // `serde_yaml::to_string` is infallible in practice; the empty-string
+        // fallback is a last resort that should never be reached for well-formed
+        // serde_yaml Values. `.trim()` removes the trailing newline that
+        // serde_yaml always appends.
         other => serde_yaml::to_string(&other)
-            .unwrap_or_default()
+            .unwrap_or_else(|_| "<unserializable>".to_string())
             .trim()
             .to_string(),
     }
@@ -372,8 +376,11 @@ fn parse_volume_short(s: &str) -> VolumeSpec {
 }
 
 /// Classify a volume source string as a bind mount or a named volume.
+///
+/// Docker Compose treats sources starting with `.`, `/`, or `~` as host paths
+/// (bind mounts). Everything else is a named volume.
 fn classify_source(source: &str, target: &str, read_only: bool) -> VolumeSpec {
-    if source.starts_with('.') || source.starts_with('/') {
+    if source.starts_with('.') || source.starts_with('/') || source.starts_with('~') {
         VolumeSpec::Bind {
             host_path: PathBuf::from(source),
             container_path: PathBuf::from(target),
@@ -628,5 +635,104 @@ mod tests {
             "services:\n  svc:\n    image: nginx\n    restart: always\nnetworks:\n  default:\n";
         let result = parse_compose(yaml);
         assert!(result.is_ok(), "should tolerate unknown keys: {result:?}");
+    }
+
+    // ------------------------------------------------------------------
+    // Volume short-syntax: tilde home-directory prefix
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_volume_short_tilde_is_bind() {
+        // `~` prefix must be classified as a Bind mount, not a Named volume.
+        let spec = parse_volume_short("~/projects/app:/app");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("~/projects/app"),
+                container_path: PathBuf::from("/app"),
+                read_only: false,
+            },
+            "tilde-prefixed source must be Bind, not Named"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Long-form volume syntax tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn volume_long_form_bind_happy_path() {
+        // Long-form bind with source present → Bind variant.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: bind\n        source: ./src\n        target: /app/src\n        read_only: true\n";
+        let file = parse_compose(yaml).expect("should parse long-form bind");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(svc.volumes.len(), 1);
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./src"),
+                container_path: PathBuf::from("/app/src"),
+                read_only: true,
+            }
+        );
+    }
+
+    #[test]
+    fn volume_long_form_bind_missing_source_returns_invalid_service() {
+        // Long-form bind with no source → InvalidService error.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: bind\n        target: /app/src\n";
+        let err = parse_compose(yaml).expect_err("should fail with missing source");
+        assert!(
+            matches!(
+                &err,
+                ComposeParseError::InvalidService { name, message }
+                    if name == "svc" && message.contains("bind volume missing")
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn volume_long_form_named_with_source() {
+        // Long-form volume type with source → Named variant.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: volume\n        source: mydata\n        target: /var/lib/data\n";
+        let file = parse_compose(yaml).expect("should parse long-form named");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Named {
+                volume_name: "mydata".to_string(),
+                container_path: PathBuf::from("/var/lib/data"),
+                read_only: false,
+            }
+        );
+    }
+
+    #[test]
+    fn volume_long_form_volume_without_source_is_anonymous() {
+        // Long-form volume type with no source → Anonymous variant.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: volume\n        target: /tmp/cache\n";
+        let file = parse_compose(yaml).expect("should parse long-form anonymous");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/tmp/cache"),
+            }
+        );
+    }
+
+    #[test]
+    fn volume_long_form_unknown_kind_falls_back_to_anonymous() {
+        // Unknown `type` string → Anonymous fallback, no error.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: tmpfs\n        target: /tmp\n";
+        let file = parse_compose(yaml).expect("should tolerate unknown volume type");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/tmp"),
+            }
+        );
     }
 }

--- a/src/parser/compose.rs
+++ b/src/parser/compose.rs
@@ -1,0 +1,632 @@
+//! Parser for `docker-compose.yml` files.
+//!
+//! # Design
+//!
+//! Compose YAML uses "dual-form" fields extensively: `build` can be a plain
+//! string or a map; `environment` can be a list or a dict; `depends_on` can
+//! be a list or a map; etc.  Serde handles this through `#[serde(untagged)]`
+//! enums defined *privately* in this module.  The public surface only exposes
+//! the clean domain types from [`crate::model::compose`].
+//!
+//! # Entry point
+//!
+//! [`parse_compose`] is the single public function.  It deserialises the raw
+//! YAML into private intermediate types, validates required keys, then
+//! converts everything into the domain model.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::model::compose::{
+    BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition, VolumeSpec,
+};
+use crate::parser::error::ComposeParseError;
+
+// ---------------------------------------------------------------------------
+// Private serde intermediate types
+// ---------------------------------------------------------------------------
+
+/// Top-level Compose file structure.
+///
+/// `services` is `Option` so we can detect its absence and return
+/// [`ComposeParseError::MissingServicesKey`] rather than a confusing YAML
+/// error.  Unknown top-level keys (e.g. `networks:`, `version:`) are ignored
+/// thanks to `#[serde(default)]` and the lack of `deny_unknown_fields`.
+#[derive(Deserialize, Default)]
+struct RawComposeFile {
+    services: Option<BTreeMap<String, RawService>>,
+    #[serde(default)]
+    volumes: BTreeMap<String, Option<RawVolumeDefinition>>,
+}
+
+/// Raw service definition — all fields are optional so we never fail on an
+/// unknown or absent key.
+#[derive(Deserialize, Default)]
+struct RawService {
+    build: Option<RawBuild>,
+    image: Option<String>,
+    #[serde(default)]
+    environment: Option<RawEnv>,
+    #[serde(default)]
+    env_file: Option<RawEnvFile>,
+    #[serde(default)]
+    volumes: Vec<RawVolumeSpec>,
+    working_dir: Option<String>,
+    #[serde(default)]
+    depends_on: Option<RawDependsOn>,
+    #[serde(default)]
+    ports: Vec<String>,
+}
+
+/// `build` can be a plain string (short form) or a map (long form).
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawBuild {
+    /// Short form: `build: ./app`
+    Short(String),
+    /// Long form: `build: { context: ./app, dockerfile: Dockerfile.dev }`
+    Full {
+        context: String,
+        #[serde(default = "default_dockerfile")]
+        dockerfile: String,
+    },
+}
+
+fn default_dockerfile() -> String {
+    "Dockerfile".to_string()
+}
+
+/// `environment` can be a list of strings or a mapping.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawEnv {
+    /// List form: `- KEY=value` or `- KEY`
+    List(Vec<String>),
+    /// Dict form: `KEY: value` (values may be strings, numbers, bools)
+    Dict(BTreeMap<String, serde_yaml::Value>),
+}
+
+/// `env_file` can be a single string or a list.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawEnvFile {
+    Single(String),
+    List(Vec<String>),
+}
+
+/// `depends_on` can be a list of service names or a map with condition objects.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawDependsOn {
+    List(Vec<String>),
+    /// Dict form: `depends_on: { db: { condition: service_healthy } }`
+    /// We only collect the keys (service names); conditions are not modelled.
+    Dict(BTreeMap<String, serde_yaml::Value>),
+}
+
+/// A single volume spec in the per-service `volumes:` list.
+///
+/// Each entry is either a short string (`"./src:/app:ro"`) or a long map form.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawVolumeSpec {
+    Short(String),
+    Long {
+        #[serde(rename = "type")]
+        kind: String,
+        source: Option<String>,
+        target: String,
+        #[serde(default)]
+        read_only: bool,
+    },
+}
+
+/// A top-level named volume declaration.  May be `null` (bare name) or a map.
+#[derive(Deserialize, Default)]
+struct RawVolumeDefinition {
+    #[serde(default)]
+    external: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Parse a `docker-compose.yml` file from a string slice.
+///
+/// Returns a [`ComposeFile`] on success, or a [`ComposeParseError`] describing
+/// the first structural problem encountered.
+///
+/// Unknown YAML keys (e.g. `networks:`, `restart:`, `healthcheck:`) are
+/// silently ignored so that real-world Compose files remain usable even when
+/// they use features that `demu` does not yet model.
+pub fn parse_compose(input: &str) -> Result<ComposeFile, ComposeParseError> {
+    // Deserialise raw YAML into the intermediate representation.
+    let raw: RawComposeFile =
+        serde_yaml::from_str(input).map_err(|e| ComposeParseError::InvalidYaml {
+            message: e.to_string(),
+        })?;
+
+    // `services:` is required — fail with a clear message if absent.
+    let raw_services = raw.services.ok_or(ComposeParseError::MissingServicesKey)?;
+
+    // Convert each raw service into the domain model.
+    let mut services = BTreeMap::new();
+    for (name, raw_svc) in raw_services {
+        let service = convert_service(name.clone(), raw_svc)?;
+        services.insert(name, service);
+    }
+
+    // Convert top-level volume declarations.
+    let volumes = raw
+        .volumes
+        .into_iter()
+        .map(|(name, raw_vol)| {
+            let def = VolumeDefinition {
+                external: raw_vol.map(|v| v.external).unwrap_or(false),
+            };
+            (name, def)
+        })
+        .collect();
+
+    Ok(ComposeFile { services, volumes })
+}
+
+// ---------------------------------------------------------------------------
+// Private conversion helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a [`RawService`] into a [`Service`] domain type.
+fn convert_service(name: String, raw: RawService) -> Result<Service, ComposeParseError> {
+    let build = raw.build.map(convert_build);
+    let environment = convert_env(raw.environment);
+    let env_file = convert_env_file(raw.env_file);
+    let volumes = raw
+        .volumes
+        .into_iter()
+        .map(|v| convert_volume_spec(v, &name))
+        .collect::<Result<Vec<_>, _>>()?;
+    let depends_on = convert_depends_on(raw.depends_on);
+
+    Ok(Service {
+        name,
+        build,
+        image: raw.image,
+        environment,
+        env_file,
+        volumes,
+        working_dir: raw.working_dir.map(PathBuf::from),
+        depends_on,
+        ports: raw.ports,
+    })
+}
+
+/// Convert a [`RawBuild`] into a [`BuildConfig`].
+fn convert_build(raw: RawBuild) -> BuildConfig {
+    match raw {
+        RawBuild::Short(ctx) => BuildConfig {
+            context: PathBuf::from(&ctx),
+            dockerfile: PathBuf::from("Dockerfile"),
+        },
+        RawBuild::Full {
+            context,
+            dockerfile,
+        } => BuildConfig {
+            context: PathBuf::from(context),
+            dockerfile: PathBuf::from(dockerfile),
+        },
+    }
+}
+
+/// Convert a [`RawEnv`] (or absent value) into a list of [`EnvEntry`] items.
+fn convert_env(raw: Option<RawEnv>) -> Vec<EnvEntry> {
+    match raw {
+        None => vec![],
+        Some(RawEnv::List(items)) => items.into_iter().map(parse_env_string).collect(),
+        Some(RawEnv::Dict(map)) => map
+            .into_iter()
+            .map(|(k, v)| EnvEntry::KeyValue {
+                key: k,
+                value: yaml_value_to_string(v),
+            })
+            .collect(),
+    }
+}
+
+/// Parse a single environment string in `KEY` or `KEY=value` form.
+fn parse_env_string(s: String) -> EnvEntry {
+    // Split on the *first* `=` only so that values containing `=` are
+    // preserved intact (e.g. `BASE64=abc=def`).
+    match s.split_once('=') {
+        Some((key, value)) => EnvEntry::KeyValue {
+            key: key.to_string(),
+            value: value.to_string(),
+        },
+        None => EnvEntry::KeyOnly { key: s },
+    }
+}
+
+/// Convert a `serde_yaml::Value` to a string representation.
+///
+/// This handles the common case of numeric and boolean values appearing in
+/// the `environment` dict form (e.g. `PORT: 3000`).
+fn yaml_value_to_string(v: serde_yaml::Value) -> String {
+    match v {
+        serde_yaml::Value::String(s) => s,
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        serde_yaml::Value::Null => String::new(),
+        // Nested sequences/mappings are stringified as YAML — unusual but safe.
+        other => serde_yaml::to_string(&other)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    }
+}
+
+/// Convert a [`RawEnvFile`] (or absent value) into a list of [`PathBuf`]s.
+fn convert_env_file(raw: Option<RawEnvFile>) -> Vec<PathBuf> {
+    match raw {
+        None => vec![],
+        Some(RawEnvFile::Single(s)) => vec![PathBuf::from(s)],
+        Some(RawEnvFile::List(items)) => items.into_iter().map(PathBuf::from).collect(),
+    }
+}
+
+/// Convert a [`RawDependsOn`] (or absent value) into a list of service name
+/// strings.
+fn convert_depends_on(raw: Option<RawDependsOn>) -> Vec<String> {
+    match raw {
+        None => vec![],
+        Some(RawDependsOn::List(items)) => items,
+        Some(RawDependsOn::Dict(map)) => map.into_keys().collect(),
+    }
+}
+
+/// Convert a [`RawVolumeSpec`] into a [`VolumeSpec`] domain type.
+///
+/// Returns an error only when the long form specifies an unrecognised `type`
+/// value — in practice this should not happen with valid Compose files.
+fn convert_volume_spec(
+    raw: RawVolumeSpec,
+    service_name: &str,
+) -> Result<VolumeSpec, ComposeParseError> {
+    match raw {
+        RawVolumeSpec::Short(s) => Ok(parse_volume_short(&s)),
+        RawVolumeSpec::Long {
+            kind,
+            source,
+            target,
+            read_only,
+        } => {
+            match kind.as_str() {
+                "bind" => {
+                    // Long-form bind requires a source.
+                    let host_path = source.map(PathBuf::from).ok_or_else(|| {
+                        ComposeParseError::InvalidService {
+                            name: service_name.to_string(),
+                            message: "bind volume missing 'source'".to_string(),
+                        }
+                    })?;
+                    Ok(VolumeSpec::Bind {
+                        host_path,
+                        container_path: PathBuf::from(target),
+                        read_only,
+                    })
+                }
+                "volume" => {
+                    let volume_name = source.unwrap_or_default();
+                    if volume_name.is_empty() {
+                        Ok(VolumeSpec::Anonymous {
+                            container_path: PathBuf::from(target),
+                        })
+                    } else {
+                        Ok(VolumeSpec::Named {
+                            volume_name,
+                            container_path: PathBuf::from(target),
+                            read_only,
+                        })
+                    }
+                }
+                // Unknown long-form type — treat as anonymous with the target
+                // path so the file is still usable.
+                _ => Ok(VolumeSpec::Anonymous {
+                    container_path: PathBuf::from(target),
+                }),
+            }
+        }
+    }
+}
+
+/// Parse the short volume syntax `[source:]target[:options]`.
+///
+/// Classification rules:
+/// - No source → `Anonymous`
+/// - Source starts with `.` or `/` → `Bind` (host path)
+/// - Otherwise → `Named` (Docker-managed named volume)
+fn parse_volume_short(s: &str) -> VolumeSpec {
+    // Options are always the last colon-separated token when present.
+    // We need to be careful: an absolute path like `/host/path:/app` has three
+    // parts but no options; `./src:/app:ro` has three parts with options.
+    let parts: Vec<&str> = s.splitn(3, ':').collect();
+
+    match parts.as_slice() {
+        // Single segment → anonymous volume.
+        [target] => VolumeSpec::Anonymous {
+            container_path: PathBuf::from(*target),
+        },
+        // Two segments → source:target, no options.
+        [source, target] => classify_source(source, target, false),
+        // Three segments → source:target:options.
+        [source, target, options] => {
+            let read_only = *options == "ro";
+            classify_source(source, target, read_only)
+        }
+        // Unreachable with splitn(3) but satisfies exhaustiveness.
+        _ => VolumeSpec::Anonymous {
+            container_path: PathBuf::from(s),
+        },
+    }
+}
+
+/// Classify a volume source string as a bind mount or a named volume.
+fn classify_source(source: &str, target: &str, read_only: bool) -> VolumeSpec {
+    if source.starts_with('.') || source.starts_with('/') {
+        VolumeSpec::Bind {
+            host_path: PathBuf::from(source),
+            container_path: PathBuf::from(target),
+            read_only,
+        }
+    } else {
+        VolumeSpec::Named {
+            volume_name: source.to_string(),
+            container_path: PathBuf::from(target),
+            read_only,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Volume short-syntax tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_volume_short_bind() {
+        // Relative source path → Bind mount, not read-only.
+        let spec = parse_volume_short("./src:/app/src");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./src"),
+                container_path: PathBuf::from("/app/src"),
+                read_only: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_bind_readonly() {
+        // `:ro` suffix → read_only true.
+        let spec = parse_volume_short("./src:/app/src:ro");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./src"),
+                container_path: PathBuf::from("/app/src"),
+                read_only: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_named() {
+        // Non-path source → Named volume.
+        let spec = parse_volume_short("data:/var/lib/data");
+        assert_eq!(
+            spec,
+            VolumeSpec::Named {
+                volume_name: "data".to_string(),
+                container_path: PathBuf::from("/var/lib/data"),
+                read_only: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_anonymous() {
+        // Single path with no source → Anonymous.
+        let spec = parse_volume_short("/app/cache");
+        assert_eq!(
+            spec,
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/app/cache"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_absolute_bind() {
+        // Absolute host path → Bind mount.
+        let spec = parse_volume_short("/host/path:/app");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("/host/path"),
+                container_path: PathBuf::from("/app"),
+                read_only: false,
+            }
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Environment entry parsing tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_env_list_key_value() {
+        let entry = parse_env_string("KEY=value".to_string());
+        assert_eq!(
+            entry,
+            EnvEntry::KeyValue {
+                key: "KEY".to_string(),
+                value: "value".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_env_list_key_only() {
+        let entry = parse_env_string("KEY".to_string());
+        assert_eq!(
+            entry,
+            EnvEntry::KeyOnly {
+                key: "KEY".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_env_dict_string_value() {
+        // Dict form with a plain string value.
+        let yaml = "services:\n  svc:\n    environment:\n      KEY: val\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert!(svc.environment.contains(&EnvEntry::KeyValue {
+            key: "KEY".to_string(),
+            value: "val".to_string(),
+        }));
+    }
+
+    #[test]
+    fn parse_env_dict_numeric_value() {
+        // Numeric values in the dict form must be stringified.
+        let yaml = "services:\n  svc:\n    environment:\n      PORT: 3000\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert!(svc.environment.contains(&EnvEntry::KeyValue {
+            key: "PORT".to_string(),
+            value: "3000".to_string(),
+        }));
+    }
+
+    // ------------------------------------------------------------------
+    // Build config tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn build_string_shorthand() {
+        // Short-form string → dockerfile defaults to "Dockerfile".
+        let yaml = "services:\n  api:\n    build: ./app\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        let build = svc.build.as_ref().expect("build present");
+        assert_eq!(build.context, PathBuf::from("./app"));
+        assert_eq!(build.dockerfile, PathBuf::from("Dockerfile"));
+    }
+
+    #[test]
+    fn build_map_with_dockerfile() {
+        // Long-form map → explicit dockerfile path preserved.
+        let yaml = "services:\n  api:\n    build:\n      context: ./app\n      dockerfile: Dockerfile.dev\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        let build = svc.build.as_ref().expect("build present");
+        assert_eq!(build.context, PathBuf::from("./app"));
+        assert_eq!(build.dockerfile, PathBuf::from("Dockerfile.dev"));
+    }
+
+    // ------------------------------------------------------------------
+    // depends_on tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn depends_on_list() {
+        let yaml =
+            "services:\n  api:\n    image: nginx\n    depends_on:\n      - db\n      - cache\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        let mut deps = svc.depends_on.clone();
+        deps.sort();
+        assert_eq!(deps, vec!["cache", "db"]);
+    }
+
+    #[test]
+    fn depends_on_dict() {
+        // Dict form — only service names (keys) should be collected.
+        let yaml =
+            "services:\n  api:\n    image: nginx\n    depends_on:\n      db:\n        condition: service_healthy\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        assert_eq!(svc.depends_on, vec!["db"]);
+    }
+
+    // ------------------------------------------------------------------
+    // env_file tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn env_file_string() {
+        let yaml = "services:\n  svc:\n    image: nginx\n    env_file: .env\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(svc.env_file, vec![PathBuf::from(".env")]);
+    }
+
+    #[test]
+    fn env_file_list() {
+        let yaml =
+            "services:\n  svc:\n    image: nginx\n    env_file:\n      - .env\n      - .env.local\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.env_file,
+            vec![PathBuf::from(".env"), PathBuf::from(".env.local")]
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Error case tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn missing_services_key() {
+        // Valid YAML but no `services:` → MissingServicesKey.
+        let yaml = "version: \"3.8\"\nnetworks:\n  default:\n";
+        let err = parse_compose(yaml).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeParseError::MissingServicesKey),
+            "unexpected error variant: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_yaml() {
+        // Syntactically broken YAML → InvalidYaml.
+        let yaml = "services:\n  api:\n    build: [unclosed\n";
+        let err = parse_compose(yaml).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeParseError::InvalidYaml { .. }),
+            "unexpected error variant: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_keys_tolerated() {
+        // Extra keys like `networks:` and `restart:` must not cause errors.
+        let yaml =
+            "services:\n  svc:\n    image: nginx\n    restart: always\nnetworks:\n  default:\n";
+        let result = parse_compose(yaml);
+        assert!(result.is_ok(), "should tolerate unknown keys: {result:?}");
+    }
+}

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -10,3 +10,23 @@ pub enum ParseError {
     #[error("line {line}: {message}")]
     InvalidInstruction { line: usize, message: String },
 }
+
+/// Errors produced by the Compose YAML parser.
+///
+/// Variants distinguish structural problems (missing keys, invalid service
+/// definitions) from low-level YAML syntax errors so callers can surface
+/// meaningful messages to the user.
+#[derive(Debug, Error)]
+pub enum ComposeParseError {
+    /// The YAML could not be parsed at all (syntax error or type mismatch).
+    #[error("invalid YAML: {message}")]
+    InvalidYaml { message: String },
+
+    /// The top-level `services:` key is absent from the Compose file.
+    #[error("compose file is missing the 'services' key")]
+    MissingServicesKey,
+
+    /// A service definition is structurally invalid.
+    #[error("invalid service '{name}': {message}")]
+    InvalidService { name: String, message: String },
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,9 @@
 //! Turns Dockerfile and Compose files into typed instruction models.
 
+pub mod compose;
 pub mod dockerfile;
 pub mod error;
 
+pub use compose::parse_compose;
 pub use dockerfile::parse_dockerfile;
-pub use error::ParseError;
+pub use error::{ComposeParseError, ParseError};

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,11 +1,16 @@
 # demu — task tracking
 
-Milestone: [Release v0.3.0](https://github.com/automatedtomato/demu/milestone/3)
-Tracking issue: [#39](https://github.com/automatedtomato/demu/issues/39)
+Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
+Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
+- [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — implementation complete, 27 new tests (18 unit + 9 integration), all 635 tests passing
 
 ## Up next
+- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
+- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
+- [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
+- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 

--- a/tests/compose_fixtures.rs
+++ b/tests/compose_fixtures.rs
@@ -1,0 +1,251 @@
+//! Fixture-based integration tests for the Compose YAML parser.
+//!
+//! These tests load YAML fixture files from `tests/fixtures/compose/` and
+//! assert that the parser produces the expected domain model.  Each test was
+//! written **before** the implementation (TDD red phase) and the
+//! implementation was evolved until all tests passed (green phase).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use demu::model::compose::{BuildConfig, EnvEntry, VolumeDefinition, VolumeSpec};
+use demu::parser::compose::parse_compose;
+use demu::parser::ComposeParseError;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Load and parse the named fixture file, panicking with a helpful message on
+/// failure.
+fn load(name: &str) -> demu::model::compose::ComposeFile {
+    let path = format!("tests/fixtures/compose/{name}");
+    let input = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read fixture {path}: {e}"));
+    parse_compose(&input).unwrap_or_else(|e| panic!("parse failed for {path}: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Full fixture: two services, correct names, build config, env entries, volume
+/// specs, and depends_on.
+#[test]
+fn test_full_compose() {
+    let file = load("full.yaml");
+
+    // Exactly two services.
+    assert_eq!(file.services.len(), 2, "expected 2 services");
+    assert!(file.services.contains_key("api"), "api service missing");
+    assert!(file.services.contains_key("db"), "db service missing");
+
+    // --- api service ---
+    let api = file.services.get("api").expect("api");
+    assert_eq!(api.name, "api");
+
+    // Build config from long form.
+    let build = api.build.as_ref().expect("api build config");
+    assert_eq!(
+        *build,
+        BuildConfig {
+            context: PathBuf::from("./services/api"),
+            dockerfile: PathBuf::from("Dockerfile.dev"),
+        }
+    );
+    assert!(api.image.is_none(), "api should have no image");
+
+    // Environment: list form — NODE_ENV=production + bare DEBUG.
+    assert!(
+        api.environment.contains(&EnvEntry::KeyValue {
+            key: "NODE_ENV".to_string(),
+            value: "production".to_string(),
+        }),
+        "NODE_ENV entry missing"
+    );
+    assert!(
+        api.environment.contains(&EnvEntry::KeyOnly {
+            key: "DEBUG".to_string()
+        }),
+        "DEBUG entry missing"
+    );
+
+    // Volumes: bind mount (non-readonly) + bind mount (readonly).
+    assert!(
+        api.volumes.contains(&VolumeSpec::Bind {
+            host_path: PathBuf::from("./src"),
+            container_path: PathBuf::from("/app/src"),
+            read_only: false,
+        }),
+        "non-readonly bind volume missing"
+    );
+    assert!(
+        api.volumes.contains(&VolumeSpec::Bind {
+            host_path: PathBuf::from("./src"),
+            container_path: PathBuf::from("/app/src"),
+            read_only: true,
+        }),
+        "readonly bind volume missing"
+    );
+
+    // depends_on.
+    assert_eq!(api.depends_on, vec!["db"]);
+
+    // --- db service ---
+    let db = file.services.get("db").expect("db");
+    assert_eq!(db.image.as_deref(), Some("postgres:15"));
+    assert!(db.build.is_none(), "db should have no build config");
+
+    // Environment from dict form.
+    assert!(db.environment.contains(&EnvEntry::KeyValue {
+        key: "POSTGRES_USER".to_string(),
+        value: "app".to_string(),
+    }));
+
+    // Named volume.
+    assert!(db.volumes.contains(&VolumeSpec::Named {
+        volume_name: "pgdata".to_string(),
+        container_path: PathBuf::from("/var/lib/postgresql/data"),
+        read_only: false,
+    }));
+
+    // Top-level volumes declaration.
+    assert!(
+        file.volumes.contains_key("pgdata"),
+        "top-level pgdata volume missing"
+    );
+}
+
+/// Image-only service: `image` is Some, `build` is None.
+#[test]
+fn test_image_only_service() {
+    let file = load("image_only.yaml");
+    let db = file.services.get("db").expect("db service");
+    assert_eq!(db.image.as_deref(), Some("postgres:15"));
+    assert!(
+        db.build.is_none(),
+        "build should be None for image-only service"
+    );
+}
+
+/// Dict form of `environment`: string value + numeric value stringified.
+#[test]
+fn test_env_dict_form() {
+    let file = load("env_dict.yaml");
+    let api = file.services.get("api").expect("api service");
+
+    assert!(api.environment.contains(&EnvEntry::KeyValue {
+        key: "NODE_ENV".to_string(),
+        value: "production".to_string(),
+    }));
+    // Numeric value 3000 must have been stringified.
+    assert!(
+        api.environment.contains(&EnvEntry::KeyValue {
+            key: "PORT".to_string(),
+            value: "3000".to_string(),
+        }),
+        "PORT entry with stringified numeric value missing; got: {:?}",
+        api.environment
+    );
+}
+
+/// Named volume variant with correct fields.
+#[test]
+fn test_volume_named_fixture() {
+    let file = load("volume_named.yaml");
+    let db = file.services.get("db").expect("db service");
+
+    assert!(
+        db.volumes.contains(&VolumeSpec::Named {
+            volume_name: "pgdata".to_string(),
+            container_path: PathBuf::from("/var/lib/postgresql/data"),
+            read_only: false,
+        }),
+        "named pgdata volume missing; got: {:?}",
+        db.volumes
+    );
+
+    let vol_def = file.volumes.get("pgdata").expect("pgdata definition");
+    assert_eq!(*vol_def, VolumeDefinition { external: false });
+}
+
+/// Invalid YAML returns `ComposeParseError::InvalidYaml`.
+#[test]
+fn test_invalid_yaml_error() {
+    let path = "tests/fixtures/compose/invalid.yaml";
+    let input = std::fs::read_to_string(path).expect("fixture readable");
+    let err = parse_compose(&input).expect_err("should fail on invalid YAML");
+    assert!(
+        matches!(err, ComposeParseError::InvalidYaml { .. }),
+        "expected InvalidYaml, got: {err}"
+    );
+}
+
+/// YAML with no `services:` key returns `MissingServicesKey`.
+#[test]
+fn test_missing_services_error() {
+    let yaml = "version: \"3.8\"\nvolumes:\n  data:\n";
+    let err = parse_compose(yaml).expect_err("should fail without services");
+    assert!(
+        matches!(err, ComposeParseError::MissingServicesKey),
+        "expected MissingServicesKey, got: {err}"
+    );
+}
+
+/// Short-form `build: ./app` → `BuildConfig.dockerfile == "Dockerfile"`.
+#[test]
+fn test_build_string_shorthand_fixture() {
+    let yaml = "services:\n  api:\n    build: ./app\n";
+    let file = parse_compose(yaml).expect("should parse");
+    let api = file.services.get("api").expect("api");
+    let build = api.build.as_ref().expect("build");
+    assert_eq!(build.context, PathBuf::from("./app"));
+    assert_eq!(
+        build.dockerfile,
+        PathBuf::from("Dockerfile"),
+        "default dockerfile name should be 'Dockerfile'"
+    );
+}
+
+/// Unknown top-level keys (`networks:`) and service-level keys (`restart:`)
+/// should not cause a parse error.
+#[test]
+fn test_unknown_keys_tolerated_fixture() {
+    let yaml = concat!(
+        "services:\n",
+        "  web:\n",
+        "    image: nginx\n",
+        "    restart: always\n",
+        "networks:\n",
+        "  default:\n",
+    );
+    let result = parse_compose(yaml);
+    assert!(
+        result.is_ok(),
+        "unknown keys should be tolerated, got: {result:?}"
+    );
+}
+
+/// `depends_on` in dict form — only the service name keys should be collected.
+#[test]
+fn test_depends_on_dict_form_fixture() {
+    let yaml = concat!(
+        "services:\n",
+        "  api:\n",
+        "    image: nginx\n",
+        "    depends_on:\n",
+        "      db:\n",
+        "        condition: service_healthy\n",
+        "      cache:\n",
+        "        condition: service_started\n",
+        "  db:\n",
+        "    image: postgres:15\n",
+        "  cache:\n",
+        "    image: redis:7\n",
+    );
+    let file = parse_compose(yaml).expect("should parse");
+    let api = file.services.get("api").expect("api");
+    let mut deps = api.depends_on.clone();
+    deps.sort();
+    assert_eq!(deps, vec!["cache", "db"]);
+}

--- a/tests/fixtures/compose/env_dict.yaml
+++ b/tests/fixtures/compose/env_dict.yaml
@@ -1,0 +1,9 @@
+# Fixture exercising the dict form of `environment` including a numeric value
+# that must be coerced to a string by the parser.
+services:
+  api:
+    image: node:20
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      DEBUG: "false"

--- a/tests/fixtures/compose/full.yaml
+++ b/tests/fixtures/compose/full.yaml
@@ -1,0 +1,29 @@
+# Full fixture: exercises build config, env list, bind volumes, depends_on, and
+# named volumes across two services.
+services:
+  api:
+    build:
+      context: ./services/api
+      dockerfile: Dockerfile.dev
+    environment:
+      - NODE_ENV=production
+      - DEBUG
+    volumes:
+      - ./src:/app/src
+      - ./src:/app/src:ro
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: appdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/tests/fixtures/compose/image_only.yaml
+++ b/tests/fixtures/compose/image_only.yaml
@@ -1,0 +1,4 @@
+# Minimal fixture: single service using a pre-built image with no build config.
+services:
+  db:
+    image: postgres:15

--- a/tests/fixtures/compose/invalid.yaml
+++ b/tests/fixtures/compose/invalid.yaml
@@ -1,0 +1,5 @@
+# Syntactically broken YAML — the parser must return InvalidYaml.
+services:
+  api:
+    build: [unclosed bracket
+    image: nginx

--- a/tests/fixtures/compose/volume_named.yaml
+++ b/tests/fixtures/compose/volume_named.yaml
@@ -1,0 +1,10 @@
+# Fixture exercising a named volume mount and the corresponding top-level
+# volume declaration.
+services:
+  db:
+    image: postgres:15
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

- Pure Compose YAML parser — no engine or REPL logic
- New `src/model/compose.rs`: typed domain model (`ComposeFile`, `Service`, `BuildConfig`, `EnvEntry`, `VolumeSpec`, `VolumeDefinition`)
- New `src/parser/compose.rs`: private serde intermediate types for all dual-form fields (build string/map, environment list/dict, env_file string/list, depends_on list/dict, volumes short/long syntax)
- New `ComposeParseError` in `src/parser/error.rs`
- New deps: `serde` (derive feature), `serde_yaml 0.9`
- 27 new tests: 18 unit + 9 integration fixture-based

## Test plan

- [x] `cargo test` — 635 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Volume short syntax: bind, named, anonymous, read-only
- [x] Volume long syntax (map form)
- [x] Environment list and dict forms (including numeric values)
- [x] Build string shorthand and map form
- [x] `env_file` string and list
- [x] `depends_on` list and dict (keys only)
- [x] Unknown keys tolerated
- [x] `MissingServicesKey` and `InvalidYaml` errors

Closes #48