### PR TITLE
feat: CLI --compose and --service flags (#49)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,11 +9,56 @@ use clap::Parser;
     about = "Fast, non-destructive Docker/Compose preview shell"
 )]
 pub struct Cli {
-    /// Dockerfile to preview
+    /// Dockerfile or Compose file to preview
     #[arg(short = 'f', long = "file")]
     pub file: std::path::PathBuf,
 
-    /// Target stage (multi-stage builds)
+    /// Target stage (multi-stage Dockerfile builds)
     #[arg(long)]
     pub stage: Option<String>,
+
+    /// Switch to Compose mode (use with -f compose.yaml)
+    #[arg(long)]
+    pub compose: bool,
+
+    /// Service to inspect — required when --compose is set
+    #[arg(long)]
+    pub service: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compose_flags_are_parsed() {
+        let cli = Cli::try_parse_from([
+            "demu",
+            "--compose",
+            "-f",
+            "compose.yaml",
+            "--service",
+            "api",
+        ])
+        .expect("should parse");
+        assert!(cli.compose);
+        assert_eq!(cli.service, Some("api".to_string()));
+        assert_eq!(cli.file.to_str().unwrap(), "compose.yaml");
+    }
+
+    #[test]
+    fn compose_flag_defaults_to_false() {
+        let cli = Cli::try_parse_from(["demu", "-f", "Dockerfile"]).expect("should parse");
+        assert!(!cli.compose);
+        assert!(cli.service.is_none());
+    }
+
+    #[test]
+    fn service_without_compose_parses() {
+        // Validation is in main.rs, not clap — so this must parse without error.
+        let cli = Cli::try_parse_from(["demu", "-f", "compose.yaml", "--service", "api"])
+            .expect("should parse even without --compose");
+        assert!(!cli.compose);
+        assert_eq!(cli.service, Some("api".to_string()));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 // `demu` binary entrypoint.
 //
 // Wires together the full preview pipeline:
+//
+// Dockerfile mode (default):
 //   1. Parse CLI arguments with clap (`Cli`).
 //   2. Validate the Dockerfile path (exists and is a regular file).
 //   3. Canonicalize the path to derive an absolute build-context directory.
@@ -10,6 +12,14 @@
 //   7. Print any engine warnings to stderr.
 //   8. Hand the resulting `PreviewState` to the interactive REPL.
 //
+// Compose mode (`--compose`):
+//   1. Parse CLI arguments with clap (`Cli`).
+//   2. Validate `--service` is present.
+//   3. Validate and canonicalize the Compose file path.
+//   4. Read and parse the Compose file.
+//   5. Validate the service name exists.
+//   6. Enter the REPL with a default `PreviewState` (engine merge comes in #50).
+//
 // `run_cli` returns `anyhow::Result<()>` so that every error path funnels
 // through the single `main` handler, which formats the message as
 // `"demu: <err>"` before exiting with code 1.
@@ -17,9 +27,89 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use demu::{
-    engine, output::sanitize::sanitize_for_terminal, parser::dockerfile::parse_dockerfile,
-    repl::config::ReplConfig, repl::run_repl, Cli,
+    engine,
+    model::state::PreviewState,
+    output::sanitize::sanitize_for_terminal,
+    parser::{compose::parse_compose, dockerfile::parse_dockerfile},
+    repl::config::{ComposeContext, ReplConfig},
+    repl::run_repl,
+    Cli,
 };
+
+/// Compose-mode pipeline.
+///
+/// Validates flags, parses the Compose file, selects the service, and enters
+/// the REPL with a default `PreviewState`. Engine integration (#50) will replace
+/// the default state with a fully merged Compose view.
+fn run_compose_pipeline(cli: &Cli) -> Result<()> {
+    // ── 1. Require --service ─────────────────────────────────────────────────
+
+    let service_name = cli.service.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("--service <name> is required in compose mode (--compose)")
+    })?;
+
+    // ── 2. Validate the Compose file path ────────────────────────────────────
+
+    if !cli.file.exists() {
+        anyhow::bail!("Compose file not found: '{}'", cli.file.display());
+    }
+    if !cli.file.is_file() {
+        anyhow::bail!(
+            "'{}' is not a regular file — pass the path to a compose.yaml",
+            cli.file.display()
+        );
+    }
+
+    let canonical = cli
+        .file
+        .canonicalize()
+        .with_context(|| format!("cannot resolve path '{}'", cli.file.display()))?;
+
+    // ── 3. Read and parse the Compose file ───────────────────────────────────
+
+    let content = std::fs::read_to_string(&canonical)
+        .with_context(|| format!("cannot read '{}'", canonical.display()))?;
+
+    let compose_file = parse_compose(&content)
+        .map_err(|e| anyhow::anyhow!("failed to parse '{}': {}", canonical.display(), e))?;
+
+    // ── 4. Validate the service name ─────────────────────────────────────────
+
+    if !compose_file.services.contains_key(service_name) {
+        let safe_name = sanitize_for_terminal(service_name);
+        let available = compose_file
+            .services
+            .keys()
+            .map(|k| sanitize_for_terminal(k))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "service '{}' not found; available services: {}",
+            safe_name,
+            available
+        );
+    }
+
+    // ── 5. Build the session config ──────────────────────────────────────────
+
+    // Engine integration (#50) will replace the stub state with a full merged
+    // Compose preview. For now, enter the REPL with an empty default state so
+    // that the flags and routing are functional end-to-end.
+    let mut state = PreviewState::default();
+
+    let compose_context = ComposeContext {
+        compose_file,
+        selected_service: service_name.to_string(),
+    };
+
+    let repl_config = ReplConfig::new(canonical).with_compose_context(Some(compose_context));
+
+    // ── 6. Enter the REPL ────────────────────────────────────────────────────
+
+    run_repl(&mut state, &repl_config)?;
+
+    Ok(())
+}
 
 /// Full CLI pipeline. Returns `Err` for any unrecoverable failure.
 ///
@@ -27,6 +117,12 @@ use demu::{
 /// formatting in `main` trivially straightforward.
 fn run_cli() -> Result<()> {
     let cli = Cli::parse();
+
+    // ── Route to Compose pipeline if --compose is set ────────────────────────
+
+    if cli.compose {
+        return run_compose_pipeline(&cli);
+    }
 
     // ── 1. Validate the path ─────────────────────────────────────────────────
 

--- a/src/repl/config.rs
+++ b/src/repl/config.rs
@@ -6,16 +6,31 @@
 
 use std::path::PathBuf;
 
+use crate::model::compose::ComposeFile;
+
+/// Holds the Compose file and the currently selected service name for sessions
+/// that were started with `--compose`.
+///
+/// Stored in `ReplConfig` so that `:reload` can re-parse the Compose file and
+/// future commands such as `:services`, `:mounts`, and `:depends` can access
+/// the full service graph.
+pub struct ComposeContext {
+    /// The fully parsed Compose file.
+    pub compose_file: ComposeFile,
+    /// The name of the service selected via `--service`.
+    pub selected_service: String,
+}
+
 /// Session-level configuration for the REPL.
 ///
 /// Holds the fixed session metadata (Dockerfile path, build context directory,
-/// and optional stage selection) that the REPL needs to support `:reload`.
-/// These values are immutable after construction and are separate from
-/// `PreviewState`, which holds simulation output.
+/// optional stage selection, and optional Compose context) that the REPL needs
+/// to support `:reload`. These values are immutable after construction and are
+/// separate from `PreviewState`, which holds simulation output.
 pub struct ReplConfig {
-    /// Absolute path to the Dockerfile being previewed.
+    /// Absolute path to the Dockerfile or Compose file being previewed.
     pub dockerfile_path: PathBuf,
-    /// Absolute path to the build context directory (parent of the Dockerfile).
+    /// Absolute path to the build context directory (parent of the file).
     ///
     /// Derived automatically from `dockerfile_path.parent()` by `ReplConfig::new`.
     /// If a different context directory is required, use `ReplConfig::with_context`.
@@ -25,6 +40,11 @@ pub struct ReplConfig {
     /// `None` means "use the final stage" (default behavior).
     /// `:reload` uses this to re-apply the same selection after re-running the engine.
     pub selected_stage: Option<String>,
+    /// Present when the session was started in Compose mode (`--compose`).
+    ///
+    /// `None` in single-Dockerfile mode. When `Some`, REPL commands such as
+    /// `:services`, `:mounts`, and `:depends` are available.
+    pub compose_context: Option<ComposeContext>,
 }
 
 impl ReplConfig {
@@ -44,6 +64,7 @@ impl ReplConfig {
             dockerfile_path,
             context_dir,
             selected_stage: None,
+            compose_context: None,
         }
     }
 
@@ -57,6 +78,7 @@ impl ReplConfig {
             dockerfile_path,
             context_dir,
             selected_stage: None,
+            compose_context: None,
         }
     }
 
@@ -68,13 +90,72 @@ impl ReplConfig {
         self.selected_stage = stage;
         self
     }
+
+    /// Attach a `ComposeContext` to this config.
+    ///
+    /// Called from `main` when `--compose` is set. Makes the parsed Compose file
+    /// and selected service name available to the REPL for Compose-aware commands.
+    pub fn with_compose_context(mut self, ctx: Option<ComposeContext>) -> Self {
+        self.compose_context = ctx;
+        self
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::model::compose::ComposeFile;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
+
+    fn empty_compose_file() -> ComposeFile {
+        ComposeFile {
+            services: BTreeMap::new(),
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- ComposeContext is stored and retrieved via builder ---
+
+    #[test]
+    fn repl_config_compose_context_defaults_to_none() {
+        let config = ReplConfig::new(PathBuf::from("/project/Dockerfile"));
+        assert!(config.compose_context.is_none());
+    }
+
+    #[test]
+    fn repl_config_with_context_compose_context_defaults_to_none() {
+        let config = ReplConfig::with_context(
+            PathBuf::from("/project/docker/Dockerfile"),
+            PathBuf::from("/project"),
+        );
+        assert!(config.compose_context.is_none());
+    }
+
+    #[test]
+    fn repl_config_with_compose_context_stores_value() {
+        let ctx = ComposeContext {
+            compose_file: empty_compose_file(),
+            selected_service: "api".to_string(),
+        };
+        let config =
+            ReplConfig::new(PathBuf::from("/project/compose.yaml")).with_compose_context(Some(ctx));
+        let stored = config.compose_context.expect("should be Some");
+        assert_eq!(stored.selected_service, "api");
+    }
+
+    #[test]
+    fn repl_config_with_compose_context_none_clears() {
+        let ctx = ComposeContext {
+            compose_file: empty_compose_file(),
+            selected_service: "api".to_string(),
+        };
+        let config = ReplConfig::new(PathBuf::from("/project/compose.yaml"))
+            .with_compose_context(Some(ctx))
+            .with_compose_context(None);
+        assert!(config.compose_context.is_none());
+    }
 
     // --- ReplConfig::new derives context_dir from parent ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,16 +4,16 @@ Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
 Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
-- [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — implementation complete, 27 new tests (18 unit + 9 integration), all 635 tests passing
+- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
 
 ## Up next
-- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
 - [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
 - [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
 - [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 
+- [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — merged [#53](https://github.com/automatedtomato/demu/pull/53)
 - [x] [#42](https://github.com/automatedtomato/demu/issues/42) feat: `COPY --from=<stage>` cross-stage file copying — merged [#45](https://github.com/automatedtomato/demu/pull/45)
 - [x] [#41](https://github.com/automatedtomato/demu/issues/41) feat: multi-stage build support + `--stage` CLI flag — merged [#44](https://github.com/automatedtomato/demu/pull/44)
 - [x] [#40](https://github.com/automatedtomato/demu/issues/40) feat: `:explain <path>` REPL command

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -27,6 +27,23 @@ fn temp_dockerfile(content: &str) -> tempfile::NamedTempFile {
     f
 }
 
+/// Create a temporary Compose YAML file containing `content` and return its path.
+///
+/// The returned `tempfile::NamedTempFile` keeps the file alive for the
+/// duration of the test — do not drop it before `Command::status()` returns.
+fn temp_compose_file(content: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    f.write_all(content.as_bytes()).expect("write compose file");
+    f
+}
+
+/// Minimal valid compose YAML with an "api" service.
+const COMPOSE_WITH_API: &str = "services:\n  api:\n    image: myapp:latest\n";
+
+/// Compose YAML with two services for service-list testing.
+const COMPOSE_WITH_API_AND_DB: &str =
+    "services:\n  api:\n    image: myapp:latest\n  db:\n    image: postgres:15\n";
+
 // ── test 1: missing --file flag exits non-zero ────────────────────────────────
 
 #[test]
@@ -311,7 +328,169 @@ fn stage_flag_exits_one_with_not_implemented_error() {
     );
 }
 
-// ── test 11: empty Dockerfile (no instructions) exits 0 ──────────────────────
+// ── Compose mode tests ────────────────────────────────────────────────────────
+
+// ── test 11: --compose without --service exits 1 with clear error ─────────────
+
+#[test]
+fn compose_without_service_flag_exits_one() {
+    // `--compose` requires `--service`. Missing `--service` must exit 1 with
+    // a message that names the missing flag so the user knows how to fix it.
+    let compose = temp_compose_file(COMPOSE_WITH_API);
+
+    let output = demu()
+        .args(["--compose", "-f", compose.path().to_str().expect("path")])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--compose without --service must exit 1, got: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--service") || stderr.contains("service"),
+        "error must mention '--service', got: {stderr}"
+    );
+    assert!(
+        stderr.contains("required") || stderr.contains("compose mode"),
+        "error must say 'required' or 'compose mode', got: {stderr}"
+    );
+}
+
+// ── test 12: --compose with nonexistent service exits 1 and lists services ────
+
+#[test]
+fn compose_nonexistent_service_exits_one_with_available_list() {
+    // When `--service` names a service that does not exist in the Compose file,
+    // `demu` must exit 1 and list the available service names so the user knows
+    // what to pass.
+    let compose = temp_compose_file(COMPOSE_WITH_API_AND_DB);
+
+    let output = demu()
+        .args([
+            "--compose",
+            "-f",
+            compose.path().to_str().expect("path"),
+            "--service",
+            "nonexistent",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--compose with nonexistent service must exit 1, got: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "error must say 'not found', got: {stderr}"
+    );
+    // Both service names from the compose file must appear so the user can pick.
+    assert!(
+        stderr.contains("api"),
+        "error must list available service 'api', got: {stderr}"
+    );
+    assert!(
+        stderr.contains("db"),
+        "error must list available service 'db', got: {stderr}"
+    );
+}
+
+// ── test 13: --compose with invalid YAML exits 1 with parse error ─────────────
+
+#[test]
+fn compose_invalid_yaml_exits_one() {
+    // A file that is not valid YAML must cause `demu` to exit 1 with a message
+    // that begins with `"demu:"` and references the parse failure.
+    let compose = temp_compose_file("{ not: valid: yaml: [\n");
+
+    let output = demu()
+        .args([
+            "--compose",
+            "-f",
+            compose.path().to_str().expect("path"),
+            "--service",
+            "api",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "invalid YAML in compose mode must exit 1, got: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("demu:"),
+        "error must begin with 'demu:', got: {stderr}"
+    );
+}
+
+// ── test 14: valid --compose + --service exits 0 with EOF stdin ───────────────
+
+#[test]
+fn compose_valid_service_with_eof_stdin_exits_zero() {
+    // The happy path: a valid Compose file and a known service name. With stdin
+    // closed immediately, the REPL hits EOF and exits cleanly.
+    let compose = temp_compose_file(COMPOSE_WITH_API);
+
+    let output = demu()
+        .args([
+            "--compose",
+            "-f",
+            compose.path().to_str().expect("path"),
+            "--service",
+            "api",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert!(
+        output.status.success(),
+        "--compose with valid service + EOF stdin must exit 0, got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── test 15: Dockerfile pipeline unchanged in compose mode addition ───────────
+
+#[test]
+fn dockerfile_pipeline_unchanged_after_compose_addition() {
+    // Regression guard: `demu -f Dockerfile` must still work exactly as before.
+    // This ensures the compose branch does not accidentally break the existing flow.
+    let dockerfile = temp_dockerfile("FROM scratch\n");
+
+    let output = demu()
+        .args(["-f", dockerfile.path().to_str().expect("path")])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert!(
+        output.status.success(),
+        "existing Dockerfile pipeline must still exit 0, got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── test 11 (original): empty Dockerfile (no instructions) exits 0 ───────────
 
 #[test]
 fn empty_dockerfile_with_eof_stdin_exits_zero() {


### PR DESCRIPTION
## Summary
- Add `--compose` (bool) and `--service <name>` (optional string) flags to `Cli`
- Route `--compose` to a dedicated `run_compose_pipeline()` function; existing Dockerfile pipeline unchanged
- `ReplConfig` gains `ComposeContext` struct and `with_compose_context()` builder for Compose-aware REPL commands (#52)

## Validation
- `--service` absent in compose mode → exit 1 with clear error
- Service name not found → exit 1, lists available services (sanitized)
- YAML parse failure → exit 1 with `demu:` prefix error

## Tests
- 3 `cli.rs` unit tests (flag parsing)
- 4 `config.rs` unit tests (`ComposeContext` storage)
- 5 integration tests in `cli_entrypoint.rs` (tests 11–15, including regression guard)
- **653 tests passing**

## Test plan
- [x] `demu --compose -f compose.yaml --service api` exits 0 on EOF stdin
- [x] `demu --compose -f compose.yaml` (no `--service`) exits 1
- [x] `demu --compose -f compose.yaml --service nonexistent` exits 1, lists available
- [x] `demu --compose -f broken.yaml --service api` exits 1 with parse error
- [x] `demu -f Dockerfile` still works (regression test 15)

Closes #49