### PR TITLE
feat: Compose engine — service merge (#50)

### DIFF
--- a/src/engine/compose.rs
+++ b/src/engine/compose.rs
@@ -1,0 +1,625 @@
+//! Compose service engine — selects a service and builds its `PreviewState`.
+//!
+//! The single public entry point is [`run_compose`], which:
+//!
+//! 1. Selects the named service from a parsed [`ComposeFile`].
+//! 2. Resolves and runs the service's Dockerfile through the existing
+//!    [`engine::run`] pipeline (or starts with an empty state for image-only
+//!    services).
+//! 3. Applies Compose-level overrides: `env_file`, `environment`, `working_dir`.
+//! 4. Returns a [`ComposeEngineOutput`] with the merged state.
+//!
+//! # Override precedence (highest → lowest)
+//! 1. `environment` entries in the Compose service definition
+//! 2. `env_file` entries (last file wins for duplicate keys)
+//! 3. `ENV` instructions in the Dockerfile
+//!
+//! # Security notes
+//! - `env_file` paths are validated to stay within `compose_dir` via
+//!   canonicalization. Paths that escape the project root emit
+//!   [`Warning::EnvFileNotFound`] and are skipped.
+//! - Service names and file paths embedded in error messages are sanitized
+//!   by the caller (`main.rs`) before terminal output.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::engine;
+use crate::model::compose::{ComposeFile, EnvEntry};
+use crate::model::fs::{DirNode, FsNode};
+use crate::model::provenance::{Provenance, ProvenanceSource};
+use crate::model::state::PreviewState;
+use crate::model::warning::Warning;
+use crate::parser::dockerfile::parse_dockerfile;
+
+use super::copy::ensure_ancestors;
+
+/// Errors that prevent the Compose engine from producing a `PreviewState`.
+///
+/// These are unrecoverable failures. Recoverable conditions (missing env_file,
+/// unresolved env key) become [`Warning`]s in the returned state instead.
+#[derive(Debug, Error)]
+pub enum ComposeEngineError {
+    /// The requested service name was not found in the Compose file.
+    #[error("service '{name}' not found in compose file")]
+    ServiceNotFound { name: String },
+
+    /// The Dockerfile referenced by the service's build config does not exist.
+    #[error("Dockerfile not found: '{}'", path.display())]
+    DockerfileNotFound { path: PathBuf },
+
+    /// The Dockerfile content could not be parsed.
+    #[error("Dockerfile parse error: {message}")]
+    ParseError { message: String },
+
+    /// The engine failed while processing the Dockerfile instructions.
+    #[error("engine error: {message}")]
+    EngineError { message: String },
+
+    /// A host filesystem I/O error occurred that was not recoverable.
+    #[error("I/O error: {message}")]
+    Io { message: String },
+}
+
+/// The output of a successful compose engine run.
+#[derive(Debug)]
+pub struct ComposeEngineOutput {
+    /// The merged `PreviewState` reflecting Dockerfile + Compose overrides.
+    pub state: PreviewState,
+    /// The original `ComposeFile` (owned copy, used by `:reload`).
+    pub compose_file: ComposeFile,
+    /// The name of the service that was selected.
+    pub selected_service: String,
+}
+
+/// Run the Compose service pipeline.
+///
+/// # Arguments
+/// - `compose_file` — the parsed Compose file
+/// - `service_name` — the service to preview (must exist in `compose_file`)
+/// - `compose_dir` — the directory containing the `compose.yaml` file;
+///   used to resolve relative `build.context`, `env_file`, and `working_dir`
+///   paths
+///
+/// # Returns
+/// A [`ComposeEngineOutput`] with the merged preview state on success, or a
+/// [`ComposeEngineError`] for unrecoverable failures. Recoverable conditions
+/// (missing env_file, unresolved env keys, image-only service) are recorded as
+/// warnings in the returned state.
+pub fn run_compose(
+    compose_file: &ComposeFile,
+    service_name: &str,
+    compose_dir: &Path,
+) -> Result<ComposeEngineOutput, ComposeEngineError> {
+    // ── 1. Select the service ─────────────────────────────────────────────────
+
+    let service = compose_file.services.get(service_name).ok_or_else(|| {
+        ComposeEngineError::ServiceNotFound {
+            name: service_name.to_string(),
+        }
+    })?;
+
+    // ── 2. Build initial state (Dockerfile or empty) ──────────────────────────
+
+    let mut state = match &service.build {
+        Some(build_config) => {
+            // Resolve: compose_dir / context / dockerfile
+            let context_dir = compose_dir.join(&build_config.context);
+            let dockerfile_path = context_dir.join(&build_config.dockerfile);
+
+            if !dockerfile_path.is_file() {
+                return Err(ComposeEngineError::DockerfileNotFound {
+                    path: dockerfile_path,
+                });
+            }
+
+            let content =
+                std::fs::read_to_string(&dockerfile_path).map_err(|e| ComposeEngineError::Io {
+                    message: format!("cannot read '{}': {e}", dockerfile_path.display()),
+                })?;
+
+            let instructions =
+                parse_dockerfile(&content).map_err(|e| ComposeEngineError::ParseError {
+                    message: e.to_string(),
+                })?;
+
+            let engine_output = engine::run(instructions, &context_dir).map_err(|e| {
+                ComposeEngineError::EngineError {
+                    message: e.to_string(),
+                }
+            })?;
+
+            engine_output.state
+        }
+        None => {
+            // Image-only service: start from an empty state and record a warning.
+            let mut s = PreviewState::default();
+            let image = service
+                .image
+                .clone()
+                .unwrap_or_else(|| "<unknown>".to_string());
+            s.active_stage = Some(image.clone());
+            s.warnings.push(Warning::ImageOnlyService { image });
+            s
+        }
+    };
+
+    // ── 3. Apply env_file entries (lower precedence than environment) ─────────
+
+    // Canonicalize compose_dir once for path-containment checks.
+    // If canonicalization fails (e.g. compose_dir does not exist), fall back
+    // to using it as-is — the env_file paths will simply fail to resolve.
+    let canonical_compose_dir = compose_dir
+        .canonicalize()
+        .unwrap_or_else(|_| compose_dir.to_path_buf());
+
+    for env_file_path in &service.env_file {
+        let resolved = compose_dir.join(env_file_path);
+
+        // Security: canonicalize and check the path stays within compose_dir.
+        // Paths that escape the project root are treated as missing.
+        let safe = match resolved.canonicalize() {
+            Ok(canon) => {
+                if canon.starts_with(&canonical_compose_dir) {
+                    Some(canon)
+                } else {
+                    // Path escaped the project root — treat as missing.
+                    None
+                }
+            }
+            Err(_) => None,
+        };
+
+        match safe {
+            Some(safe_path) => match std::fs::read_to_string(&safe_path) {
+                Ok(content) => parse_env_file(&content, &mut state.env),
+                Err(_) => {
+                    state.warnings.push(Warning::EnvFileNotFound {
+                        path: env_file_path.clone(),
+                    });
+                }
+            },
+            None => {
+                state.warnings.push(Warning::EnvFileNotFound {
+                    path: env_file_path.clone(),
+                });
+            }
+        }
+    }
+
+    // ── 4. Apply environment entries (highest precedence) ─────────────────────
+
+    for entry in &service.environment {
+        match entry {
+            EnvEntry::KeyValue { key, value } => {
+                state.env.insert(key.clone(), value.clone());
+            }
+            EnvEntry::KeyOnly { key } => {
+                // At preview time the host environment is not available.
+                // Record a warning and skip rather than inserting a wrong value.
+                state
+                    .warnings
+                    .push(Warning::UnresolvedEnvKey { key: key.clone() });
+            }
+        }
+    }
+
+    // ── 5. Apply working_dir override ─────────────────────────────────────────
+
+    if let Some(ref working_dir) = service.working_dir {
+        let new_cwd = if working_dir.is_absolute() {
+            working_dir.clone()
+        } else {
+            state.cwd.join(working_dir)
+        };
+
+        // Ensure the directory and its ancestors exist in the virtual filesystem,
+        // mirroring how the engine handles WORKDIR instructions.
+        let prov = ProvenanceSource::Workdir;
+        ensure_ancestors(&mut state.fs, &new_cwd, prov.clone());
+        if !state.fs.contains(&new_cwd) {
+            state.fs.insert(
+                new_cwd.clone(),
+                FsNode::Directory(DirNode {
+                    provenance: Provenance::new(prov),
+                    permissions: None,
+                }),
+            );
+        }
+
+        state.cwd = new_cwd;
+    }
+
+    Ok(ComposeEngineOutput {
+        state,
+        compose_file: compose_file.clone(),
+        selected_service: service_name.to_string(),
+    })
+}
+
+/// Parse a `.env` file and insert entries into `env`.
+///
+/// Format rules (following Docker Compose env_file conventions):
+/// - Lines starting with `#` are comments and are skipped.
+/// - Empty or whitespace-only lines are skipped.
+/// - Lines of the form `KEY=value` are inserted; `value` may be empty.
+/// - Lines without `=` are skipped (not valid env entries in this context).
+fn parse_env_file(content: &str, env: &mut std::collections::BTreeMap<String, String>) {
+    for line in content.lines() {
+        let line = line.trim();
+        // Skip comments and blank lines.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Split on the first `=` only; everything after is the value.
+        if let Some(eq_pos) = line.find('=') {
+            let key = &line[..eq_pos];
+            let value = &line[eq_pos + 1..];
+            if !key.is_empty() {
+                env.insert(key.to_string(), value.to_string());
+            }
+        }
+        // Lines without `=` are skipped (bare KEY form is not valid in env_file).
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::compose::{BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition};
+    use std::collections::BTreeMap;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// Build a minimal ComposeFile with a single service.
+    fn single_service_compose(service: Service) -> ComposeFile {
+        let mut services = BTreeMap::new();
+        services.insert(service.name.clone(), service);
+        ComposeFile {
+            services,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    /// Build a bare Service with no fields set.
+    fn bare_service(name: &str) -> Service {
+        Service {
+            name: name.to_string(),
+            build: None,
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        }
+    }
+
+    /// Create a temp directory with a Dockerfile and return (TempDir, ComposeFile).
+    fn make_build_fixture(dockerfile_content: &str) -> (TempDir, ComposeFile) {
+        let dir = TempDir::new().expect("tempdir");
+        let df_path = dir.path().join("Dockerfile");
+        std::fs::write(&df_path, dockerfile_content).expect("write Dockerfile");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("svc")
+        };
+        (dir, single_service_compose(service))
+    }
+
+    // ── test 1: service not found ─────────────────────────────────────────────
+
+    #[test]
+    fn service_not_found_returns_error() {
+        let compose = ComposeFile {
+            services: BTreeMap::new(),
+            volumes: BTreeMap::new(),
+        };
+        let err = run_compose(&compose, "missing", Path::new("/tmp")).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::ServiceNotFound { .. }),
+            "expected ServiceNotFound, got: {err:?}"
+        );
+    }
+
+    // ── test 2: image-only service ────────────────────────────────────────────
+
+    #[test]
+    fn image_only_service_returns_empty_fs_with_warning() {
+        let service = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "db", Path::new("/tmp")).expect("should succeed");
+
+        // Filesystem should be effectively empty (no files from Dockerfile).
+        assert!(
+            output.state.fs.iter().count() == 0,
+            "image-only service must have empty fs; got {} nodes",
+            output.state.fs.iter().count()
+        );
+
+        // Warning::ImageOnlyService must be present.
+        let has_warning =
+            output.state.warnings.iter().any(
+                |w| matches!(w, Warning::ImageOnlyService { image } if image == "postgres:15"),
+            );
+        assert!(has_warning, "must have ImageOnlyService warning");
+
+        // active_stage should be set to the image name.
+        assert_eq!(
+            output.state.active_stage.as_deref(),
+            Some("postgres:15"),
+            "active_stage must be the image name"
+        );
+    }
+
+    // ── test 3: build service produces dockerfile filesystem ──────────────────
+
+    #[test]
+    fn build_service_produces_dockerfile_fs() {
+        let (dir, compose) = make_build_fixture("FROM scratch\nWORKDIR /app\nENV DF_VAR=hello\n");
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        // /app should exist in the virtual filesystem from WORKDIR.
+        let app_path = PathBuf::from("/app");
+        assert!(
+            output.state.fs.contains(&app_path),
+            "virtual fs must contain /app from WORKDIR"
+        );
+
+        // DF_VAR should be set from Dockerfile ENV.
+        assert_eq!(
+            output.state.env.get("DF_VAR").map(String::as_str),
+            Some("hello"),
+            "DF_VAR must be set from Dockerfile ENV"
+        );
+    }
+
+    // ── test 4: compose environment wins over dockerfile ENV ──────────────────
+
+    #[test]
+    fn env_merge_compose_wins_over_dockerfile() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nENV SHARED=from_dockerfile\n");
+
+        // Add Compose environment override.
+        compose.services.get_mut("svc").unwrap().environment = vec![EnvEntry::KeyValue {
+            key: "SHARED".to_string(),
+            value: "from_compose".to_string(),
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.env.get("SHARED").map(String::as_str),
+            Some("from_compose"),
+            "Compose environment must override Dockerfile ENV"
+        );
+    }
+
+    // ── test 5: working_dir override ─────────────────────────────────────────
+
+    #[test]
+    fn working_dir_override_sets_cwd() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nWORKDIR /app\n");
+
+        compose.services.get_mut("svc").unwrap().working_dir = Some(PathBuf::from("/override"));
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.cwd,
+            PathBuf::from("/override"),
+            "working_dir must override Dockerfile WORKDIR"
+        );
+
+        // /override should also exist in the virtual filesystem.
+        assert!(
+            output.state.fs.contains(&PathBuf::from("/override")),
+            "virtual fs must contain /override after working_dir override"
+        );
+    }
+
+    // ── test 6: env_file is loaded and merged ─────────────────────────────────
+
+    #[test]
+    fn env_file_loaded_and_merged() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("Dockerfile"), b"FROM scratch\n").expect("write df");
+        let mut env_file = std::fs::File::create(dir.path().join(".env.test")).expect("create");
+        writeln!(env_file, "ENV_FILE_VAR=from_file").expect("write env");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            env_file: vec![PathBuf::from(".env.test")],
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.env.get("ENV_FILE_VAR").map(String::as_str),
+            Some("from_file"),
+            "env var from env_file must be in state.env"
+        );
+    }
+
+    // ── test 7: missing env_file emits warning without crashing ───────────────
+
+    #[test]
+    fn missing_env_file_emits_warning() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("Dockerfile"), b"FROM scratch\n").expect("write df");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            env_file: vec![PathBuf::from(".env.nonexistent")],
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("must not error");
+
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::EnvFileNotFound { .. }));
+        assert!(has_warning, "must have EnvFileNotFound warning");
+    }
+
+    // ── test 8: KeyOnly env emits UnresolvedEnvKey warning ────────────────────
+
+    #[test]
+    fn key_only_env_emits_unresolved_warning() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\n");
+
+        compose.services.get_mut("svc").unwrap().environment = vec![EnvEntry::KeyOnly {
+            key: "HOST_VAR".to_string(),
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::UnresolvedEnvKey { key } if key == "HOST_VAR"));
+        assert!(
+            has_warning,
+            "must have UnresolvedEnvKey warning for HOST_VAR"
+        );
+
+        assert!(
+            !output.state.env.contains_key("HOST_VAR"),
+            "HOST_VAR must NOT be inserted into env"
+        );
+    }
+
+    // ── test 9: env_file before environment precedence ────────────────────────
+
+    #[test]
+    fn env_file_before_environment_precedence() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("Dockerfile"), b"FROM scratch\n").expect("write df");
+        let mut ef = std::fs::File::create(dir.path().join(".env")).expect("create");
+        writeln!(ef, "KEY=from_file").expect("write");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            env_file: vec![PathBuf::from(".env")],
+            environment: vec![EnvEntry::KeyValue {
+                key: "KEY".to_string(),
+                value: "from_compose".to_string(),
+            }],
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        // environment entries have higher precedence than env_file entries.
+        assert_eq!(
+            output.state.env.get("KEY").map(String::as_str),
+            Some("from_compose"),
+            "environment entries must win over env_file entries"
+        );
+    }
+
+    // ── test 10: dockerfile not found returns error ───────────────────────────
+
+    #[test]
+    fn dockerfile_not_found_returns_error() {
+        let dir = TempDir::new().expect("tempdir");
+        // Do NOT create Dockerfile — it should be missing.
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let err = run_compose(&compose, "svc", dir.path()).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::DockerfileNotFound { .. }),
+            "expected DockerfileNotFound, got: {err:?}"
+        );
+    }
+
+    // ── test 11: parse_env_file parses standard format ────────────────────────
+
+    #[test]
+    fn parse_env_file_handles_comments_and_blanks() {
+        let content = "# comment\n\nKEY=value\nANOTHER=one\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(env.get("KEY").map(String::as_str), Some("value"));
+        assert_eq!(env.get("ANOTHER").map(String::as_str), Some("one"));
+        assert_eq!(env.len(), 2);
+    }
+
+    #[test]
+    fn parse_env_file_handles_empty_value() {
+        let content = "EMPTY=\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(env.get("EMPTY").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parse_env_file_skips_lines_without_equals() {
+        let content = "BARE_KEY\nKEY=value\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert!(!env.contains_key("BARE_KEY"), "bare key should be skipped");
+        assert_eq!(env.get("KEY").map(String::as_str), Some("value"));
+    }
+
+    #[test]
+    fn parse_env_file_value_may_contain_equals() {
+        let content = "URL=https://example.com/?a=1&b=2\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("URL").map(String::as_str),
+            Some("https://example.com/?a=1&b=2")
+        );
+    }
+
+    // ── test 12: output fields are populated correctly ────────────────────────
+
+    #[test]
+    fn output_fields_are_populated() {
+        let (dir, compose) = make_build_fixture("FROM scratch\n");
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(output.selected_service, "svc");
+        assert!(output.compose_file.services.contains_key("svc"));
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,12 +3,17 @@
 //! The single public entry point is [`run`], which walks a `Vec<Instruction>`
 //! and returns an [`EngineOutput`] containing the final stage's [`PreviewState`]
 //! and a [`StageRegistry`] for all stages.
+//!
+//! The compose engine entry point is [`compose::run_compose`], which builds a
+//! merged `PreviewState` from a parsed `ComposeFile` and a selected service.
 
+pub mod compose;
 mod copy;
 pub mod error;
 mod run_sim;
 mod runner;
 
+pub use compose::{run_compose, ComposeEngineError, ComposeEngineOutput};
 pub use error::EngineError;
 pub use runner::{run, EngineOutput};
 // Re-export StageRegistry from the model so callers can use engine::StageRegistry

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use demu::{
     engine,
-    model::state::PreviewState,
     output::sanitize::sanitize_for_terminal,
     parser::{compose::parse_compose, dockerfile::parse_dockerfile},
     repl::config::{ComposeContext, ReplConfig},
@@ -90,21 +89,42 @@ fn run_compose_pipeline(cli: &Cli) -> Result<()> {
         );
     }
 
-    // ── 5. Build the session config ──────────────────────────────────────────
+    // ── 5. Derive the compose directory ──────────────────────────────────────
 
-    // Engine integration (#50) will replace the stub state with a full merged
-    // Compose preview. For now, enter the REPL with an empty default state so
-    // that the flags and routing are functional end-to-end.
-    let mut state = PreviewState::default();
+    let compose_dir = canonical
+        .parent()
+        .with_context(|| {
+            format!(
+                "cannot determine parent directory of '{}'",
+                canonical.display()
+            )
+        })?
+        .to_path_buf();
+
+    // ── 6. Run the compose engine ─────────────────────────────────────────────
+
+    let compose_output = engine::run_compose(&compose_file, service_name, &compose_dir)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    // ── 7. Print warnings to stderr ───────────────────────────────────────────
+
+    let mut state = compose_output.state;
+    for warning in &state.warnings {
+        let safe = sanitize_for_terminal(&warning.to_string());
+        eprintln!("warning: {safe}");
+    }
+
+    // ── 8. Build the session config ───────────────────────────────────────────
 
     let compose_context = ComposeContext {
         compose_file,
         selected_service: service_name.to_string(),
     };
 
-    let repl_config = ReplConfig::new(canonical).with_compose_context(Some(compose_context));
+    let repl_config = ReplConfig::with_context(canonical, compose_dir)
+        .with_compose_context(Some(compose_context));
 
-    // ── 6. Enter the REPL ────────────────────────────────────────────────────
+    // ── 9. Enter the REPL ────────────────────────────────────────────────────
 
     run_repl(&mut state, &repl_config)?;
 

--- a/src/model/warning.rs
+++ b/src/model/warning.rs
@@ -107,6 +107,33 @@ pub enum Warning {
         /// Source line number (1-based) where the COPY instruction appeared.
         line: usize,
     },
+
+    /// A Compose service uses `image:` but has no `build:` context.
+    ///
+    /// The preview filesystem starts empty because the engine does not extract
+    /// real image filesystems. The REPL remains functional but shows no files.
+    ImageOnlyService {
+        /// The image reference from the service's `image:` field.
+        image: String,
+    },
+
+    /// An `env_file` referenced in a Compose service definition was not found.
+    ///
+    /// The missing file is skipped and the remaining env_files and environment
+    /// entries are still applied. The REPL continues normally.
+    EnvFileNotFound {
+        /// The path that was referenced but could not be read.
+        path: PathBuf,
+    },
+
+    /// A Compose `environment` entry used the bare `KEY` form (no value).
+    ///
+    /// At preview time the host environment is not available, so the key is
+    /// skipped rather than inserted with an empty or incorrect value.
+    UnresolvedEnvKey {
+        /// The environment variable key that had no value.
+        key: String,
+    },
 }
 
 /// # Terminal output safety
@@ -173,6 +200,19 @@ impl fmt::Display for Warning {
                     "COPY --from='{}' references unknown stage at line {} (skipped)",
                     stage, line
                 )
+            }
+            Warning::ImageOnlyService { image } => {
+                write!(
+                    f,
+                    "service uses image '{}' with no build context — filesystem is empty",
+                    image
+                )
+            }
+            Warning::EnvFileNotFound { path } => {
+                write!(f, "env_file '{}' not found — skipped", path.display())
+            }
+            Warning::UnresolvedEnvKey { key } => {
+                write!(f, "environment key '{}' has no value — skipped", key)
             }
         }
     }
@@ -576,5 +616,139 @@ mod tests {
             line: 5,
         };
         assert_eq!(w.clone(), w);
+    }
+
+    // --- ImageOnlyService ---
+
+    #[test]
+    fn image_only_service_stores_image() {
+        let w = Warning::ImageOnlyService {
+            image: "postgres:15".to_string(),
+        };
+        assert_eq!(
+            w,
+            Warning::ImageOnlyService {
+                image: "postgres:15".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn display_image_only_service_contains_image_name() {
+        let w = Warning::ImageOnlyService {
+            image: "postgres:15".to_string(),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(
+            s.contains("postgres:15"),
+            "display must contain image name, got: {s}"
+        );
+        assert!(
+            s.contains("filesystem is empty"),
+            "display must mention empty filesystem, got: {s}"
+        );
+    }
+
+    #[test]
+    fn display_image_only_service_full_string() {
+        let w = Warning::ImageOnlyService {
+            image: "redis:7".to_string(),
+        };
+        assert_eq!(
+            w.to_string(),
+            "service uses image 'redis:7' with no build context \u{2014} filesystem is empty"
+        );
+    }
+
+    // --- EnvFileNotFound ---
+
+    #[test]
+    fn env_file_not_found_stores_path() {
+        let path = PathBuf::from("/project/.env.prod");
+        let w = Warning::EnvFileNotFound { path: path.clone() };
+        assert_eq!(w, Warning::EnvFileNotFound { path });
+    }
+
+    #[test]
+    fn display_env_file_not_found_contains_path() {
+        let w = Warning::EnvFileNotFound {
+            path: PathBuf::from("/project/.env"),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(s.contains(".env"), "display must contain path, got: {s}");
+        assert!(
+            s.contains("not found"),
+            "display must say 'not found', got: {s}"
+        );
+    }
+
+    #[test]
+    fn display_env_file_not_found_full_string() {
+        let w = Warning::EnvFileNotFound {
+            path: PathBuf::from(".env"),
+        };
+        assert_eq!(w.to_string(), "env_file '.env' not found \u{2014} skipped");
+    }
+
+    // --- UnresolvedEnvKey ---
+
+    #[test]
+    fn unresolved_env_key_stores_key() {
+        let w = Warning::UnresolvedEnvKey {
+            key: "HOST_TOKEN".to_string(),
+        };
+        assert_eq!(
+            w,
+            Warning::UnresolvedEnvKey {
+                key: "HOST_TOKEN".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn display_unresolved_env_key_contains_key_name() {
+        let w = Warning::UnresolvedEnvKey {
+            key: "SECRET".to_string(),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(
+            s.contains("SECRET"),
+            "display must contain key name, got: {s}"
+        );
+        assert!(
+            s.contains("no value"),
+            "display must mention 'no value', got: {s}"
+        );
+    }
+
+    #[test]
+    fn display_unresolved_env_key_full_string() {
+        let w = Warning::UnresolvedEnvKey {
+            key: "MY_VAR".to_string(),
+        };
+        assert_eq!(
+            w.to_string(),
+            "environment key 'MY_VAR' has no value \u{2014} skipped"
+        );
+    }
+
+    #[test]
+    fn new_warning_variants_clone_and_equal() {
+        let w1 = Warning::ImageOnlyService {
+            image: "img".to_string(),
+        };
+        let w2 = Warning::EnvFileNotFound {
+            path: PathBuf::from("/a"),
+        };
+        let w3 = Warning::UnresolvedEnvKey {
+            key: "K".to_string(),
+        };
+        assert_eq!(w1.clone(), w1);
+        assert_eq!(w2.clone(), w2);
+        assert_eq!(w3.clone(), w3);
+        assert_ne!(w1, w3);
     }
 }

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use crate::engine;
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::parser::dockerfile::parse_dockerfile;
+use crate::parser::{compose::parse_compose, dockerfile::parse_dockerfile};
 use crate::repl::config::ReplConfig;
 use crate::repl::error::{io_err_mapper, ReplError};
 
@@ -34,6 +34,12 @@ pub fn execute(
     writer: &mut impl Write,
     err_writer: &mut impl Write,
 ) -> Result<(), ReplError> {
+    // Compose mode: re-parse the compose file and re-run the compose engine.
+    // The Dockerfile pipeline is the `else` branch below.
+    if config.compose_context.is_some() {
+        return execute_compose(state, config, writer, err_writer);
+    }
+
     // Step 1: Read the Dockerfile from disk.
     // Sanitize the path before embedding it in terminal output — the path
     // comes from the CLI argument and could theoretically contain control bytes.
@@ -119,11 +125,86 @@ pub fn execute(
     Ok(())
 }
 
+/// Reload for Compose mode.
+///
+/// Re-reads the compose file, re-parses it, and re-runs the compose engine
+/// for the previously selected service. On any error, the old state is
+/// preserved and the error is written to `err_writer`.
+fn execute_compose(
+    state: &mut PreviewState,
+    config: &ReplConfig,
+    writer: &mut impl Write,
+    err_writer: &mut impl Write,
+) -> Result<(), ReplError> {
+    // The compose context must be present when this function is called.
+    // Safe to unwrap: checked by the caller (`execute`).
+    let ctx = config
+        .compose_context
+        .as_ref()
+        .expect("compose_context must be Some in execute_compose");
+
+    // Step 1: Re-read the compose file.
+    let content = match std::fs::read_to_string(&config.dockerfile_path) {
+        Ok(c) => c,
+        Err(e) => {
+            let safe_path = sanitize_for_terminal(&config.dockerfile_path.display().to_string());
+            writeln!(
+                err_writer,
+                "demu: cannot read compose file '{}': {e}",
+                safe_path
+            )
+            .map_err(io_err_mapper(":reload"))?;
+            return Ok(());
+        }
+    };
+
+    // Step 2: Re-parse the compose file.
+    let compose_file = match parse_compose(&content) {
+        Ok(cf) => cf,
+        Err(e) => {
+            let safe_msg = sanitize_for_terminal(&e.to_string());
+            writeln!(err_writer, "demu: compose parse error: {safe_msg}")
+                .map_err(io_err_mapper(":reload"))?;
+            return Ok(());
+        }
+    };
+
+    // Step 3: Re-run the compose engine.
+    let compose_output =
+        match engine::run_compose(&compose_file, &ctx.selected_service, &config.context_dir) {
+            Ok(out) => out,
+            Err(e) => {
+                let safe_msg = sanitize_for_terminal(&e.to_string());
+                writeln!(err_writer, "demu: compose engine error: {safe_msg}")
+                    .map_err(io_err_mapper(":reload"))?;
+                return Ok(());
+            }
+        };
+
+    // Step 4: Emit warnings, replace state, confirm.
+    let new_state = compose_output.state;
+    for w in &new_state.warnings {
+        writeln!(
+            err_writer,
+            "warning: {}",
+            sanitize_for_terminal(&w.to_string())
+        )
+        .map_err(io_err_mapper(":reload"))?;
+    }
+
+    let n = new_state.history.len();
+    *state = new_state;
+    writeln!(writer, "Reloaded. {n} instructions processed.").map_err(io_err_mapper(":reload"))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::repl::config::ReplConfig;
+    use crate::model::compose::ComposeFile;
+    use crate::repl::config::{ComposeContext, ReplConfig};
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
@@ -507,6 +588,141 @@ mod tests {
         assert!(
             !state.env.contains_key("CTX_FINAL"),
             "state must NOT be final stage"
+        );
+    }
+
+    // ── Compose mode reload tests ─────────────────────────────────────────────
+
+    /// Build a minimal `ComposeFile` with a single build service.
+    fn make_compose_file_with_service(service_name: &str) -> ComposeFile {
+        use crate::model::compose::{BuildConfig, Service, VolumeDefinition};
+        use std::collections::BTreeMap;
+        let service = Service {
+            name: service_name.to_string(),
+            build: Some(BuildConfig {
+                context: std::path::PathBuf::from("."),
+                dockerfile: std::path::PathBuf::from("Dockerfile"),
+            }),
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        };
+        let mut services = BTreeMap::new();
+        services.insert(service_name.to_string(), service);
+        ComposeFile {
+            services,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- reload_compose_mode_replaces_state ---
+    //
+    // Compose mode reload: after a reload, the state reflects the env vars
+    // set in the Dockerfile referenced by the compose file.
+
+    #[test]
+    fn reload_compose_mode_replaces_state() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(
+            dir.path().join("Dockerfile"),
+            b"FROM scratch\nENV RELOAD_VAR=ok\n",
+        )
+        .expect("write Dockerfile");
+
+        let compose_yaml = format!(
+            "services:\n  api:\n    build:\n      context: .\n      dockerfile: Dockerfile\n    environment:\n      - COMPOSE_VAR=hello\n"
+        );
+        let compose_path = dir.path().join("compose.yaml");
+        std::fs::write(&compose_path, compose_yaml.as_bytes()).expect("write compose.yaml");
+
+        let ctx = ComposeContext {
+            compose_file: make_compose_file_with_service("api"),
+            selected_service: "api".to_string(),
+        };
+        let config = ReplConfig::with_context(compose_path, dir.path().to_path_buf())
+            .with_compose_context(Some(ctx));
+        let mut state = PreviewState::default();
+
+        let (result, out, _err) = run_reload(&mut state, &config);
+        assert!(result.is_ok(), "execute must return Ok; got: {result:?}");
+        assert!(
+            out.contains("Reloaded."),
+            "stdout must contain 'Reloaded.'; got: {out}"
+        );
+        assert_eq!(
+            state.env.get("COMPOSE_VAR").map(String::as_str),
+            Some("hello"),
+            "state must contain COMPOSE_VAR=hello from compose environment"
+        );
+    }
+
+    // --- reload_compose_mode_parse_error_keeps_old_state ---
+    //
+    // If the compose file is invalid YAML on reload, old state is preserved.
+
+    #[test]
+    fn reload_compose_mode_parse_error_keeps_old_state() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let compose_path = dir.path().join("compose.yaml");
+        std::fs::write(&compose_path, b"{ not: valid: yaml: [\n").expect("write bad yaml");
+
+        let ctx = ComposeContext {
+            compose_file: make_compose_file_with_service("api"),
+            selected_service: "api".to_string(),
+        };
+        let config = ReplConfig::with_context(compose_path, dir.path().to_path_buf())
+            .with_compose_context(Some(ctx));
+        let mut state = PreviewState::default();
+        state.cwd = PathBuf::from("/original");
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(
+            result.is_ok(),
+            "execute must return Ok on parse error; got: {result:?}"
+        );
+        assert_eq!(
+            state.cwd,
+            PathBuf::from("/original"),
+            "state must be preserved on parse error"
+        );
+        assert!(
+            err.contains("parse error") || err.contains("compose"),
+            "stderr must mention compose parse error; got: {err}"
+        );
+    }
+
+    // --- reload_compose_mode_emits_warnings ---
+    //
+    // An image-only service emits ImageOnlyService warning on reload.
+
+    #[test]
+    fn reload_compose_mode_emits_warnings() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let compose_path = dir.path().join("compose.yaml");
+        let compose_yaml = "services:\n  db:\n    image: postgres:15\n";
+        std::fs::write(&compose_path, compose_yaml.as_bytes()).expect("write compose");
+
+        let ctx = ComposeContext {
+            compose_file: make_compose_file_with_service("db"),
+            selected_service: "db".to_string(),
+        };
+        let config = ReplConfig::with_context(compose_path, dir.path().to_path_buf())
+            .with_compose_context(Some(ctx));
+        let mut state = PreviewState::default();
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(result.is_ok());
+        assert!(
+            err.contains("warning:"),
+            "stderr must contain 'warning:' for ImageOnlyService; got: {err}"
+        );
+        assert!(
+            err.contains("filesystem is empty") || err.contains("postgres"),
+            "warning must mention the image or empty filesystem; got: {err}"
         );
     }
 }

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -137,11 +137,12 @@ fn execute_compose(
     err_writer: &mut impl Write,
 ) -> Result<(), ReplError> {
     // The compose context must be present when this function is called.
-    // Safe to unwrap: checked by the caller (`execute`).
-    let ctx = config
-        .compose_context
-        .as_ref()
-        .expect("compose_context must be Some in execute_compose");
+    // The caller (`execute`) routes here only when `compose_context.is_some()`.
+    // Return early rather than panic to maintain the REPL's non-crashing guarantee.
+    let ctx = match config.compose_context.as_ref() {
+        Some(ctx) => ctx,
+        None => return Ok(()),
+    };
 
     // Step 1: Re-read the compose file.
     let content = match std::fs::read_to_string(&config.dockerfile_path) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,15 +4,15 @@ Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
 Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
-- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
+- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
 
 ## Up next
-- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
 - [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
 - [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 
+- [x] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags — merged [#56](https://github.com/automatedtomato/demu/pull/56)
 - [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — merged [#53](https://github.com/automatedtomato/demu/pull/53)
 - [x] [#42](https://github.com/automatedtomato/demu/issues/42) feat: `COPY --from=<stage>` cross-stage file copying — merged [#45](https://github.com/automatedtomato/demu/pull/45)
 - [x] [#41](https://github.com/automatedtomato/demu/issues/41) feat: multi-stage build support + `--stage` CLI flag — merged [#44](https://github.com/automatedtomato/demu/pull/44)

--- a/tests/compose_engine.rs
+++ b/tests/compose_engine.rs
@@ -1,0 +1,238 @@
+// Integration tests for the Compose engine (issue #50).
+//
+// These tests use fixture files under `tests/fixtures/compose/engine/` to
+// exercise the full parse-and-run pipeline end-to-end, asserting on the
+// resulting `PreviewState` fields.
+
+use std::path::{Path, PathBuf};
+
+use demu::{engine::run_compose, model::warning::Warning, parser::compose::parse_compose};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Path to the fixture directory for compose engine tests.
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/compose/engine")
+}
+
+/// Parse a compose file fixture by name and return the `ComposeFile`.
+fn parse_fixture(filename: &str) -> demu::model::compose::ComposeFile {
+    let path = fixture_dir().join(filename);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read fixture '{}': {e}", path.display()));
+    parse_compose(&content)
+        .unwrap_or_else(|e| panic!("failed to parse fixture '{}': {e}", path.display()))
+}
+
+// ── test 1: build service produces Dockerfile filesystem ─────────────────────
+
+#[test]
+fn build_service_produces_dockerfile_filesystem() {
+    // compose_build.yaml points at the Dockerfile in the same directory.
+    // The Dockerfile sets WORKDIR /app, so /app must be in the virtual FS.
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    // /app should exist from the Dockerfile's WORKDIR instruction.
+    let app_path = PathBuf::from("/app");
+    assert!(
+        output.state.fs.contains(&app_path),
+        "virtual fs must contain /app from Dockerfile WORKDIR"
+    );
+
+    // DF_VAR is set in the Dockerfile; compose_build.yaml doesn't override it.
+    assert_eq!(
+        output.state.env.get("DF_VAR").map(String::as_str),
+        Some("from_dockerfile"),
+        "DF_VAR must be set from Dockerfile ENV"
+    );
+}
+
+// ── test 2: compose environment wins over dockerfile ENV ─────────────────────
+
+#[test]
+fn compose_environment_wins_over_dockerfile_env() {
+    // compose_build.yaml: environment: [SHARED=from_compose, COMPOSE_VAR=from_compose]
+    // Dockerfile:         ENV SHARED=from_dockerfile
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    // Compose environment must override Dockerfile ENV for SHARED.
+    assert_eq!(
+        output.state.env.get("SHARED").map(String::as_str),
+        Some("from_compose"),
+        "SHARED must be from Compose environment, not Dockerfile ENV"
+    );
+
+    // COMPOSE_VAR is Compose-only (not in Dockerfile).
+    assert_eq!(
+        output.state.env.get("COMPOSE_VAR").map(String::as_str),
+        Some("from_compose"),
+        "COMPOSE_VAR must be present from Compose environment"
+    );
+}
+
+// ── test 3: working_dir overrides Dockerfile WORKDIR ─────────────────────────
+
+#[test]
+fn working_dir_overrides_dockerfile_workdir() {
+    // compose_build.yaml sets working_dir: /override
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    assert_eq!(
+        output.state.cwd,
+        PathBuf::from("/override"),
+        "cwd must be /override from compose working_dir"
+    );
+
+    // /override must also exist in the virtual filesystem.
+    assert!(
+        output.state.fs.contains(&PathBuf::from("/override")),
+        "virtual fs must contain /override"
+    );
+}
+
+// ── test 4: image-only service has empty filesystem with warning ──────────────
+
+#[test]
+fn image_only_service_empty_fs_with_warning() {
+    let compose = parse_fixture("compose_image_only.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "db", &dir).expect("compose engine must succeed");
+
+    // Filesystem must be empty (no Dockerfile ran).
+    assert_eq!(
+        output.state.fs.iter().count(),
+        0,
+        "image-only service must have empty fs"
+    );
+
+    // ImageOnlyService warning must be present.
+    let has_warning =
+        output.state.warnings.iter().any(
+            |w| matches!(w, Warning::ImageOnlyService { image } if image.contains("postgres")),
+        );
+    assert!(
+        has_warning,
+        "must have ImageOnlyService warning for postgres"
+    );
+}
+
+// ── test 5: image-only service gets compose environment applied ───────────────
+
+#[test]
+fn image_only_service_gets_compose_environment() {
+    // compose_image_only.yaml: environment: [DB_VAR=hello]
+    let compose = parse_fixture("compose_image_only.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "db", &dir).expect("compose engine must succeed");
+
+    assert_eq!(
+        output.state.env.get("DB_VAR").map(String::as_str),
+        Some("hello"),
+        "DB_VAR from compose environment must be applied even for image-only service"
+    );
+}
+
+// ── test 6: env_file is loaded and merged ─────────────────────────────────────
+
+#[test]
+fn env_file_loaded_and_merged() {
+    // compose_env_file.yaml references .env.test, which sets:
+    //   ENV_FILE_VAR=from_env_file
+    //   SHARED=from_env_file
+    // The compose file also sets environment: [SHARED=from_compose]
+    // So SHARED should be "from_compose" (environment wins over env_file).
+    let compose = parse_fixture("compose_env_file.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    assert_eq!(
+        output.state.env.get("ENV_FILE_VAR").map(String::as_str),
+        Some("from_env_file"),
+        "ENV_FILE_VAR must be loaded from env_file"
+    );
+
+    // Compose environment wins over env_file for SHARED.
+    assert_eq!(
+        output.state.env.get("SHARED").map(String::as_str),
+        Some("from_compose"),
+        "SHARED: environment entry must win over env_file entry"
+    );
+}
+
+// ── test 7: missing env_file emits warning without crashing ───────────────────
+
+#[test]
+fn missing_env_file_emits_warning_without_crash() {
+    let compose = parse_fixture("compose_missing_env_file.yaml");
+    let dir = fixture_dir();
+
+    // Must not return an error — missing env_file is non-fatal.
+    let output =
+        run_compose(&compose, "api", &dir).expect("missing env_file must not be a fatal error");
+
+    let has_warning = output
+        .state
+        .warnings
+        .iter()
+        .any(|w| matches!(w, Warning::EnvFileNotFound { .. }));
+    assert!(has_warning, "must have EnvFileNotFound warning");
+}
+
+// ── test 8: KeyOnly env emits UnresolvedEnvKey warning ────────────────────────
+
+#[test]
+fn key_only_env_emits_unresolved_warning() {
+    // compose_key_only_env.yaml: environment: [HOST_VAR, DEFINED_VAR=has_value]
+    let compose = parse_fixture("compose_key_only_env.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("should succeed");
+
+    let has_warning = output
+        .state
+        .warnings
+        .iter()
+        .any(|w| matches!(w, Warning::UnresolvedEnvKey { key } if key == "HOST_VAR"));
+    assert!(
+        has_warning,
+        "must have UnresolvedEnvKey warning for HOST_VAR"
+    );
+
+    // HOST_VAR must NOT be in env.
+    assert!(
+        !output.state.env.contains_key("HOST_VAR"),
+        "HOST_VAR must not be in state.env"
+    );
+
+    // DEFINED_VAR must be in env.
+    assert_eq!(
+        output.state.env.get("DEFINED_VAR").map(String::as_str),
+        Some("has_value"),
+        "DEFINED_VAR must be present with correct value"
+    );
+}
+
+// ── test 9: output fields are correct ─────────────────────────────────────────
+
+#[test]
+fn output_selected_service_and_compose_file_are_correct() {
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("should succeed");
+
+    assert_eq!(output.selected_service, "api");
+    assert!(output.compose_file.services.contains_key("api"));
+}

--- a/tests/fixtures/compose/engine/.env.test
+++ b/tests/fixtures/compose/engine/.env.test
@@ -1,0 +1,3 @@
+# Test env file
+ENV_FILE_VAR=from_env_file
+SHARED=from_env_file

--- a/tests/fixtures/compose/engine/Dockerfile
+++ b/tests/fixtures/compose/engine/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ENV DF_VAR=from_dockerfile
+ENV SHARED=from_dockerfile
+WORKDIR /app

--- a/tests/fixtures/compose/engine/compose_build.yaml
+++ b/tests/fixtures/compose/engine/compose_build.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - SHARED=from_compose
+      - COMPOSE_VAR=from_compose
+    working_dir: /override

--- a/tests/fixtures/compose/engine/compose_env_file.yaml
+++ b/tests/fixtures/compose/engine/compose_env_file.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.test
+    environment:
+      - SHARED=from_compose

--- a/tests/fixtures/compose/engine/compose_image_only.yaml
+++ b/tests/fixtures/compose/engine/compose_image_only.yaml
@@ -1,0 +1,5 @@
+services:
+  db:
+    image: postgres:15
+    environment:
+      - DB_VAR=hello

--- a/tests/fixtures/compose/engine/compose_key_only_env.yaml
+++ b/tests/fixtures/compose/engine/compose_key_only_env.yaml
@@ -1,0 +1,8 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - HOST_VAR
+      - DEFINED_VAR=has_value

--- a/tests/fixtures/compose/engine/compose_missing_env_file.yaml
+++ b/tests/fixtures/compose/engine/compose_missing_env_file.yaml
@@ -1,0 +1,7 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.nonexistent


### PR DESCRIPTION
## Summary
- Add `engine::compose::run_compose()` that builds a merged `PreviewState` from a Compose service
- Build services: resolve Dockerfile path, run through existing engine pipeline
- Image-only services (no `build:`): empty fs + `Warning::ImageOnlyService`
- `env_file`: parsed line-by-line, applied before `environment` entries  
- `environment`: `KeyValue` entries override Dockerfile `ENV`; `KeyOnly` entries emit `Warning::UnresolvedEnvKey`
- `working_dir`: overrides `state.cwd`, creates directory node in virtual FS
- `env_file` path security: canonicalized + containment check against `compose_dir`
- `:reload` now supports compose mode (re-parses compose file + re-runs compose engine)

## New warnings
- `Warning::ImageOnlyService { image }` — filesystem is empty for image-only services
- `Warning::EnvFileNotFound { path }` — missing env_file is non-fatal
- `Warning::UnresolvedEnvKey { key }` — bare `KEY` env entries are skipped

## Test plan
- [x] Build service produces Dockerfile-derived filesystem
- [x] Compose `environment` wins over Dockerfile `ENV`
- [x] `working_dir` overrides Dockerfile `WORKDIR`
- [x] Image-only service: empty FS + `ImageOnlyService` warning
- [x] `env_file` loaded and merged; precedence: environment > env_file > Dockerfile
- [x] Missing `env_file` → `EnvFileNotFound` warning, no crash
- [x] `KeyOnly` env → `UnresolvedEnvKey` warning, not inserted
- [x] `:reload` in compose mode re-runs compose engine
- [x] `:reload` compose parse error preserves old state
- [x] 690 tests passing

Closes #50