### PR TITLE
feat: mount shadow model (#51)

### DIFF
--- a/src/engine/compose.rs
+++ b/src/engine/compose.rs
@@ -34,6 +34,7 @@ use crate::model::warning::Warning;
 use crate::parser::dockerfile::parse_dockerfile;
 
 use super::copy::ensure_ancestors;
+use super::mount::apply_mount_shadows;
 
 /// Errors that prevent the Compose engine from producing a `PreviewState`.
 ///
@@ -231,6 +232,10 @@ pub fn run_compose(
         state.cwd = new_cwd;
     }
 
+    // ── 6. Apply volume mount shadows ─────────────────────────────────────────
+
+    apply_mount_shadows(&mut state, &service.volumes);
+
     Ok(ComposeEngineOutput {
         state,
         compose_file: compose_file.clone(),
@@ -268,7 +273,9 @@ fn parse_env_file(content: &str, env: &mut std::collections::BTreeMap<String, St
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::model::compose::{BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition};
+    use crate::model::compose::{
+        BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition, VolumeSpec,
+    };
     use std::collections::BTreeMap;
     use std::io::Write;
     use tempfile::TempDir;
@@ -621,5 +628,49 @@ mod tests {
 
         assert_eq!(output.selected_service, "svc");
         assert!(output.compose_file.services.contains_key("svc"));
+    }
+
+    // ── test 13: volume mounts are applied as shadows ─────────────────────────
+
+    #[test]
+    fn bind_volume_recorded_in_state_mounts() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nWORKDIR /app\n");
+
+        compose.services.get_mut("svc").unwrap().volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./data"),
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.mounts.len(),
+            1,
+            "one bind mount must be recorded"
+        );
+        assert!(
+            output.state.mounts[0]
+                .description
+                .contains("bind mount from"),
+            "description must mention bind mount; got: {}",
+            output.state.mounts[0].description
+        );
+    }
+
+    #[test]
+    fn named_volume_recorded_in_state_mounts() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\n");
+
+        compose.services.get_mut("svc").unwrap().volumes = vec![VolumeSpec::Named {
+            volume_name: "my-cache".to_string(),
+            container_path: PathBuf::from("/cache"),
+            read_only: false,
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(output.state.mounts.len(), 1);
+        assert_eq!(output.state.mounts[0].description, "named volume: my-cache");
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,7 @@
 pub mod compose;
 mod copy;
 pub mod error;
+pub mod mount;
 mod run_sim;
 mod runner;
 

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -11,8 +11,6 @@
 // The host filesystem is never accessed — `host_path` values in `Bind`
 // specs are used only as display strings in the mount description.
 
-use std::path::Path;
-
 use crate::model::compose::VolumeSpec;
 use crate::model::provenance::MountInfo;
 use crate::model::state::PreviewState;
@@ -29,10 +27,11 @@ use crate::model::state::PreviewState;
 pub fn apply_mount_shadows(state: &mut PreviewState, volumes: &[VolumeSpec]) {
     for vol in volumes {
         let info = build_mount_info(vol);
-        let container_path = container_path_of(vol);
 
-        // Shadow any FS node that already exists at this container path.
-        if let Some(node) = state.fs.get_mut(container_path) {
+        // Shadow any FS node that already exists at the container path.
+        // Using `info.container_path` directly avoids a redundant extraction
+        // and keeps the path used for FS lookup in sync with the stored mount.
+        if let Some(node) = state.fs.get_mut(&info.container_path) {
             node.provenance_mut().shadowed_by_mount = Some(info.clone());
         }
 
@@ -71,15 +70,6 @@ fn build_mount_info(spec: &VolumeSpec) -> MountInfo {
             read_only: false,
             description: "anonymous volume".to_string(),
         },
-    }
-}
-
-/// Extract the container path from any `VolumeSpec` variant.
-fn container_path_of(spec: &VolumeSpec) -> &Path {
-    match spec {
-        VolumeSpec::Bind { container_path, .. } => container_path,
-        VolumeSpec::Named { container_path, .. } => container_path,
-        VolumeSpec::Anonymous { container_path } => container_path,
     }
 }
 
@@ -288,5 +278,50 @@ mod tests {
         let mut state = PreviewState::default();
         apply_mount_shadows(&mut state, &[]);
         assert!(state.mounts.is_empty());
+    }
+
+    // --- duplicate container path: last-writer-wins for shadowed_by_mount ---
+    //
+    // When two VolumeSpec entries share the same container path, state.mounts
+    // records both (so `:mounts` shows two entries) but the FS node's
+    // shadowed_by_mount carries only the last one (last-writer-wins).
+    // This test specifies that behavior explicitly so any future change is
+    // visible.
+
+    #[test]
+    fn duplicate_container_path_last_writer_wins_for_fs_shadow() {
+        let mut state = state_with_dir("/data");
+        let volumes = vec![
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./first"),
+                container_path: PathBuf::from("/data"),
+                read_only: false,
+            },
+            VolumeSpec::Named {
+                volume_name: "second".to_string(),
+                container_path: PathBuf::from("/data"),
+                read_only: true,
+            },
+        ];
+        apply_mount_shadows(&mut state, &volumes);
+
+        // Both entries are recorded in state.mounts.
+        assert_eq!(state.mounts.len(), 2, "both mounts must be in state.mounts");
+
+        // The FS node at /data retains only the last mount shadow (last-writer-wins).
+        let node = state
+            .fs
+            .get(&PathBuf::from("/data"))
+            .expect("/data must exist");
+        let shadow = node
+            .provenance()
+            .shadowed_by_mount
+            .as_ref()
+            .expect("must be shadowed");
+        assert_eq!(
+            shadow.description, "named volume: second",
+            "last VolumeSpec must win for shadowed_by_mount; got: {}",
+            shadow.description
+        );
     }
 }

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -1,0 +1,292 @@
+// Mount shadow engine — applies Compose volume mounts to the preview state.
+//
+// `apply_mount_shadows` converts each `VolumeSpec` from a Compose service
+// definition into a `MountInfo` record and:
+//
+// 1. Attaches the mount info to any existing FS node at the container path
+//    (so `:explain` can report that a path is shadowed by a volume mount).
+// 2. Appends the mount info to `state.mounts` (so `:mounts` can list all
+//    active mount shadows).
+//
+// The host filesystem is never accessed — `host_path` values in `Bind`
+// specs are used only as display strings in the mount description.
+
+use std::path::Path;
+
+use crate::model::compose::VolumeSpec;
+use crate::model::provenance::MountInfo;
+use crate::model::state::PreviewState;
+
+/// Apply volume mount shadows from `volumes` to `state`.
+///
+/// For each `VolumeSpec`:
+/// - A `MountInfo` is constructed with the container path, read-only flag,
+///   and a human-readable description.
+/// - If an FS node exists at the container path it is annotated with
+///   `shadowed_by_mount`.
+/// - The mount info is always recorded in `state.mounts` regardless of
+///   whether a matching FS node exists.
+pub fn apply_mount_shadows(state: &mut PreviewState, volumes: &[VolumeSpec]) {
+    for vol in volumes {
+        let info = build_mount_info(vol);
+        let container_path = container_path_of(vol);
+
+        // Shadow any FS node that already exists at this container path.
+        if let Some(node) = state.fs.get_mut(container_path) {
+            node.provenance_mut().shadowed_by_mount = Some(info.clone());
+        }
+
+        // Always record in the mounts list for `:mounts` display.
+        state.mounts.push(info);
+    }
+}
+
+/// Build a `MountInfo` from a `VolumeSpec`.
+///
+/// The `description` is computed once here so it can be stored in both
+/// `Provenance::shadowed_by_mount` and `state.mounts` without needing
+/// to reconstruct it at display time.
+fn build_mount_info(spec: &VolumeSpec) -> MountInfo {
+    match spec {
+        VolumeSpec::Bind {
+            host_path,
+            container_path,
+            read_only,
+        } => MountInfo {
+            container_path: container_path.clone(),
+            read_only: *read_only,
+            description: format!("bind mount from {}", host_path.display()),
+        },
+        VolumeSpec::Named {
+            volume_name,
+            container_path,
+            read_only,
+        } => MountInfo {
+            container_path: container_path.clone(),
+            read_only: *read_only,
+            description: format!("named volume: {volume_name}"),
+        },
+        VolumeSpec::Anonymous { container_path } => MountInfo {
+            container_path: container_path.clone(),
+            read_only: false,
+            description: "anonymous volume".to_string(),
+        },
+    }
+}
+
+/// Extract the container path from any `VolumeSpec` variant.
+fn container_path_of(spec: &VolumeSpec) -> &Path {
+    match spec {
+        VolumeSpec::Bind { container_path, .. } => container_path,
+        VolumeSpec::Named { container_path, .. } => container_path,
+        VolumeSpec::Anonymous { container_path } => container_path,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::fs::{DirNode, FileNode, FsNode};
+    use crate::model::provenance::{Provenance, ProvenanceSource};
+    use crate::model::state::PreviewState;
+    use std::path::PathBuf;
+
+    fn workdir_provenance() -> Provenance {
+        Provenance::new(ProvenanceSource::Workdir)
+    }
+
+    fn state_with_dir(path: &str) -> PreviewState {
+        let mut state = PreviewState::default();
+        let node = FsNode::Directory(DirNode {
+            provenance: workdir_provenance(),
+            permissions: None,
+        });
+        state.fs.insert(PathBuf::from(path), node);
+        state
+    }
+
+    fn state_with_file(path: &str) -> PreviewState {
+        let mut state = PreviewState::default();
+        let node = FsNode::File(FileNode {
+            content: vec![],
+            provenance: workdir_provenance(),
+            permissions: None,
+        });
+        state.fs.insert(PathBuf::from(path), node);
+        state
+    }
+
+    // --- apply_mount_shadows: records mounts in state.mounts ---
+
+    #[test]
+    fn bind_spec_is_recorded_in_state_mounts() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./data"),
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 1);
+        assert_eq!(state.mounts[0].container_path, PathBuf::from("/data"));
+        // PathBuf strips leading "./" — "bind mount from data" is expected.
+        assert!(
+            state.mounts[0].description.starts_with("bind mount from"),
+            "got: {}",
+            state.mounts[0].description
+        );
+        assert!(!state.mounts[0].read_only);
+    }
+
+    #[test]
+    fn named_spec_is_recorded_in_state_mounts() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Named {
+            volume_name: "npm-cache".to_string(),
+            container_path: PathBuf::from("/root/.npm"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 1);
+        assert_eq!(state.mounts[0].description, "named volume: npm-cache");
+        assert_eq!(state.mounts[0].container_path, PathBuf::from("/root/.npm"));
+    }
+
+    #[test]
+    fn anonymous_spec_is_recorded_in_state_mounts() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Anonymous {
+            container_path: PathBuf::from("/tmp/scratch"),
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 1);
+        assert_eq!(state.mounts[0].description, "anonymous volume");
+        assert!(!state.mounts[0].read_only);
+    }
+
+    #[test]
+    fn read_only_bind_sets_read_only_true_in_mount_info() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./config"),
+            container_path: PathBuf::from("/config"),
+            read_only: true,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert!(state.mounts[0].read_only);
+    }
+
+    #[test]
+    fn read_only_named_sets_read_only_true_in_mount_info() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Named {
+            volume_name: "shared-data".to_string(),
+            container_path: PathBuf::from("/shared"),
+            read_only: true,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert!(state.mounts[0].read_only);
+    }
+
+    // --- apply_mount_shadows: shadows existing FS nodes ---
+
+    #[test]
+    fn existing_dir_node_gets_shadowed_by_bind_mount() {
+        let mut state = state_with_dir("/data");
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./data"),
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+
+        let node = state
+            .fs
+            .get(&PathBuf::from("/data"))
+            .expect("/data must exist");
+        let shadow = node
+            .provenance()
+            .shadowed_by_mount
+            .as_ref()
+            .expect("must be shadowed");
+        assert_eq!(shadow.container_path, PathBuf::from("/data"));
+        assert!(shadow.description.contains("bind mount from"));
+    }
+
+    #[test]
+    fn existing_file_node_gets_shadowed_by_named_mount() {
+        let mut state = state_with_file("/app/config.json");
+        let volumes = vec![VolumeSpec::Named {
+            volume_name: "config-vol".to_string(),
+            container_path: PathBuf::from("/app/config.json"),
+            read_only: true,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+
+        let node = state
+            .fs
+            .get(&PathBuf::from("/app/config.json"))
+            .expect("must exist");
+        let shadow = node
+            .provenance()
+            .shadowed_by_mount
+            .as_ref()
+            .expect("must be shadowed");
+        assert_eq!(shadow.description, "named volume: config-vol");
+        assert!(shadow.read_only);
+    }
+
+    // --- apply_mount_shadows: nonexistent path still records mount ---
+
+    #[test]
+    fn nonexistent_container_path_still_records_in_state_mounts() {
+        // The path doesn't exist in the FS — no node to shadow — but
+        // the mount must still appear in state.mounts for `:mounts`.
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./uploads"),
+            container_path: PathBuf::from("/uploads"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(
+            state.mounts.len(),
+            1,
+            "mount must be recorded even without an FS node"
+        );
+        // No node at /uploads — FS remains empty.
+        assert!(state.fs.get(&PathBuf::from("/uploads")).is_none());
+    }
+
+    // --- apply_mount_shadows: multiple volumes ---
+
+    #[test]
+    fn multiple_volumes_all_recorded() {
+        let mut state = PreviewState::default();
+        let volumes = vec![
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./data"),
+                container_path: PathBuf::from("/data"),
+                read_only: false,
+            },
+            VolumeSpec::Named {
+                volume_name: "cache".to_string(),
+                container_path: PathBuf::from("/cache"),
+                read_only: false,
+            },
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/tmp"),
+            },
+        ];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 3);
+    }
+
+    #[test]
+    fn empty_volumes_list_leaves_state_unchanged() {
+        let mut state = PreviewState::default();
+        apply_mount_shadows(&mut state, &[]);
+        assert!(state.mounts.is_empty());
+    }
+}

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::model::{
-    provenance::{MountInfo, MountKind, ProvenanceSource},
+    provenance::{MountInfo, ProvenanceSource},
     state::PreviewState,
 };
 use crate::output::sanitize::sanitize_for_terminal;
@@ -122,17 +122,10 @@ fn format_source(source: &ProvenanceSource) -> String {
 
 /// Format a `MountInfo` as a human-readable string.
 ///
-/// The output describes the kind of mount and the source path or name.
-/// The `source` field is user-supplied and sanitized before interpolation.
+/// Returns the pre-formatted `description` field, sanitizing it against
+/// ANSI escape injection before emitting it to the terminal.
 fn format_mount(mount: &MountInfo) -> String {
-    let safe_source = sanitize_for_terminal(&mount.source);
-    match mount.mount_type {
-        MountKind::Bind => format!("bind mount from {safe_source}"),
-        MountKind::Volume => format!("volume mount: {safe_source}"),
-        MountKind::Tmpfs => "tmpfs mount".to_string(),
-        MountKind::Cache => format!("cache mount from {safe_source}"),
-        MountKind::Secret => format!("secret mount: {safe_source}"),
-    }
+    sanitize_for_terminal(&mount.description)
 }
 
 #[cfg(test)]
@@ -141,7 +134,7 @@ mod tests {
     use super::*;
     use crate::model::{
         fs::{FileNode, FsNode},
-        provenance::{MountInfo, MountKind, Provenance, ProvenanceSource},
+        provenance::{MountInfo, Provenance, ProvenanceSource},
         state::PreviewState,
     };
     use std::path::PathBuf;
@@ -268,8 +261,9 @@ mod tests {
             host_path: PathBuf::from("src/main.rs"),
         });
         prov.shadowed_by_mount = Some(MountInfo {
-            source: "/host/path".to_string(),
-            mount_type: MountKind::Bind,
+            container_path: PathBuf::from("/app/main.rs"),
+            read_only: false,
+            description: "bind mount from /host/path".to_string(),
         });
         let state = state_with_node("/app/main.rs", prov);
         let output = explain_path(&state, Path::new("/app/main.rs")).expect("should succeed");
@@ -352,42 +346,36 @@ mod tests {
         );
     }
 
-    // --- mount kind format tests ---
+    // --- mount description format tests ---
 
     #[test]
-    fn format_mount_volume_shows_volume_name() {
+    fn format_mount_returns_description() {
         let mount = MountInfo {
-            source: "myvolume".to_string(),
-            mount_type: MountKind::Volume,
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "named volume: myvolume".to_string(),
         };
-        assert_eq!(format_mount(&mount), "volume mount: myvolume");
+        assert_eq!(format_mount(&mount), "named volume: myvolume");
     }
 
     #[test]
-    fn format_mount_tmpfs_shows_tmpfs_label() {
+    fn format_mount_anonymous_volume() {
         let mount = MountInfo {
-            source: "ignored".to_string(),
-            mount_type: MountKind::Tmpfs,
+            container_path: PathBuf::from("/tmp"),
+            read_only: false,
+            description: "anonymous volume".to_string(),
         };
-        assert_eq!(format_mount(&mount), "tmpfs mount");
+        assert_eq!(format_mount(&mount), "anonymous volume");
     }
 
     #[test]
-    fn format_mount_cache_shows_source() {
+    fn format_mount_bind_description() {
         let mount = MountInfo {
-            source: "/cache/go".to_string(),
-            mount_type: MountKind::Cache,
+            container_path: PathBuf::from("/app"),
+            read_only: true,
+            description: "bind mount from ./src".to_string(),
         };
-        assert_eq!(format_mount(&mount), "cache mount from /cache/go");
-    }
-
-    #[test]
-    fn format_mount_secret_shows_name() {
-        let mount = MountInfo {
-            source: "mysecret".to_string(),
-            mount_type: MountKind::Secret,
-        };
-        assert_eq!(format_mount(&mount), "secret mount: mysecret");
+        assert_eq!(format_mount(&mount), "bind mount from ./src");
     }
 
     // --- sanitization of user-controlled fields ---
@@ -423,10 +411,11 @@ mod tests {
     }
 
     #[test]
-    fn format_mount_strips_ansi_escape_in_source() {
+    fn format_mount_strips_ansi_escape_in_description() {
         let mount = MountInfo {
-            source: "/host/\x1b[2Jpath".to_string(),
-            mount_type: MountKind::Bind,
+            container_path: PathBuf::from("/app"),
+            read_only: false,
+            description: "bind mount from /host/\x1b[2Jpath".to_string(),
         };
         let result = format_mount(&mount);
         assert!(

--- a/src/model/fs.rs
+++ b/src/model/fs.rs
@@ -66,6 +66,18 @@ impl FsNode {
             FsNode::Symlink(s) => &s.provenance,
         }
     }
+
+    /// Return a mutable reference to the provenance record embedded in this node.
+    ///
+    /// Used by the mount shadow engine to attach `MountInfo` to existing nodes
+    /// without cloning the entire node.
+    pub fn provenance_mut(&mut self) -> &mut Provenance {
+        match self {
+            FsNode::File(f) => &mut f.provenance,
+            FsNode::Directory(d) => &mut d.provenance,
+            FsNode::Symlink(s) => &mut s.provenance,
+        }
+    }
 }
 
 /// An in-memory virtual filesystem backed by a flat path-to-node map.
@@ -105,6 +117,14 @@ impl VirtualFs {
     /// Return a reference to the node at `path`, or `None` if it does not exist.
     pub fn get(&self, path: &Path) -> Option<&FsNode> {
         self.nodes.get(path)
+    }
+
+    /// Return a mutable reference to the node at `path`, or `None` if it does not exist.
+    ///
+    /// Used by the mount shadow engine to attach mount metadata to existing nodes
+    /// in-place without re-inserting them.
+    pub fn get_mut(&mut self, path: &Path) -> Option<&mut FsNode> {
+        self.nodes.get_mut(path)
     }
 
     /// Return `true` if a node exists at `path`.

--- a/src/model/provenance.rs
+++ b/src/model/provenance.rs
@@ -44,6 +44,12 @@ pub struct MountInfo {
     pub read_only: bool,
     /// Pre-formatted human-readable description of the mount source.
     ///
+    /// # Security note
+    /// This string is assembled from user-controlled YAML content (host paths,
+    /// volume names) and **must** be passed through `sanitize_for_terminal`
+    /// before writing to any terminal output. Callers that skip sanitization
+    /// are vulnerable to ANSI escape injection.
+    ///
     /// Examples:
     /// - `"bind mount from ./data"`
     /// - `"named volume: npm-cache"`

--- a/src/model/provenance.rs
+++ b/src/model/provenance.rs
@@ -30,31 +30,25 @@ pub enum ProvenanceSource {
     EnvSet { key: String, value: String },
 }
 
-/// The type of a Docker mount (`--mount=type=...`).
+/// Metadata about a volume mount that shadows a path in the virtual filesystem.
 ///
-/// Using an enum rather than a free-form string prevents typos at call sites
-/// and allows exhaustive matching in the engine and `:explain` output.
-#[derive(Debug, Clone, PartialEq)]
-pub enum MountKind {
-    /// `--mount=type=bind` — bind-mounts a host path into the build.
-    Bind,
-    /// `--mount=type=volume` — mounts a named volume.
-    Volume,
-    /// `--mount=type=tmpfs` — mounts an ephemeral tmpfs.
-    Tmpfs,
-    /// `--mount=type=cache` — mounts a persistent cache directory.
-    Cache,
-    /// `--mount=type=secret` — mounts a secret file.
-    Secret,
-}
-
-/// Metadata about a bind/volume mount that shadows a path in the virtual filesystem.
+/// `MountInfo` records where a volume mounts inside the container (`container_path`),
+/// whether it is read-only, and a pre-formatted human-readable `description` that is
+/// used by both `:explain` and `:mounts`.  The description is computed from the
+/// `VolumeSpec` variant at the time the mount shadow is applied by `engine::mount`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MountInfo {
-    /// The source of the mount (e.g. host path, named volume, or stage reference).
-    pub source: String,
-    /// The category of mount.
-    pub mount_type: MountKind,
+    /// The absolute container path at which this volume is mounted.
+    pub container_path: PathBuf,
+    /// `true` when the mount was declared `read_only` in the Compose file.
+    pub read_only: bool,
+    /// Pre-formatted human-readable description of the mount source.
+    ///
+    /// Examples:
+    /// - `"bind mount from ./data"`
+    /// - `"named volume: npm-cache"`
+    /// - `"anonymous volume"`
+    pub description: String,
 }
 
 /// Provenance record attached to every `FsNode`.
@@ -166,35 +160,46 @@ mod tests {
     // --- MountInfo construction ---
 
     #[test]
-    fn mount_info_stores_source_and_kind() {
+    fn mount_info_stores_container_path_and_description() {
         let mount = MountInfo {
-            source: "/host/cache".to_string(),
-            mount_type: MountKind::Bind,
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
         };
-        assert_eq!(mount.source, "/host/cache");
-        assert_eq!(mount.mount_type, MountKind::Bind);
+        assert_eq!(mount.container_path, PathBuf::from("/data"));
+        assert!(!mount.read_only);
+        assert_eq!(mount.description, "bind mount from ./data");
     }
 
     #[test]
-    fn all_mount_kinds_are_mutually_distinct() {
-        let kinds = [
-            MountKind::Bind,
-            MountKind::Volume,
-            MountKind::Tmpfs,
-            MountKind::Cache,
-            MountKind::Secret,
-        ];
-        // Every pair must be distinct — catches any accidental mapping of
-        // multiple variants to the same underlying discriminant.
-        for i in 0..kinds.len() {
-            for j in 0..kinds.len() {
-                if i == j {
-                    assert_eq!(kinds[i], kinds[j], "variant {i} should equal itself");
-                } else {
-                    assert_ne!(kinds[i], kinds[j], "variants {i} and {j} must be distinct");
-                }
-            }
-        }
+    fn mount_info_read_only_flag() {
+        let mount = MountInfo {
+            container_path: PathBuf::from("/cache"),
+            read_only: true,
+            description: "named volume: my-cache".to_string(),
+        };
+        assert!(mount.read_only);
+    }
+
+    #[test]
+    fn mount_info_anonymous_volume_description() {
+        let mount = MountInfo {
+            container_path: PathBuf::from("/tmp/scratch"),
+            read_only: false,
+            description: "anonymous volume".to_string(),
+        };
+        assert_eq!(mount.description, "anonymous volume");
+    }
+
+    #[test]
+    fn mount_info_clone_is_independent() {
+        let original = MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
+        };
+        let clone = original.clone();
+        assert_eq!(original, clone);
     }
 
     // --- Provenance::new ---

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use super::fs::VirtualFs;
+use super::provenance::MountInfo;
 use super::warning::Warning;
 
 /// A registry of all completed build stages, indexed by name and by number.
@@ -222,6 +223,13 @@ pub struct PreviewState {
 
     /// The currently active build stage alias, if any (used for multi-stage builds).
     pub active_stage: Option<String>,
+
+    /// Volume mount shadows applied by the Compose engine.
+    ///
+    /// Each entry records a volume mount declared in the Compose service definition.
+    /// Populated by `engine::mount::apply_mount_shadows` after the Dockerfile pipeline runs.
+    /// Used by the `:mounts` REPL command to list active mount shadows.
+    pub mounts: Vec<MountInfo>,
 }
 
 impl Default for PreviewState {
@@ -239,6 +247,7 @@ impl Default for PreviewState {
             layers: Vec::new(),
             warnings: Vec::new(),
             active_stage: None,
+            mounts: Vec::new(),
         }
     }
 }

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -38,6 +38,7 @@ CUSTOM COMMANDS (prefix with :)
   :installed               show simulated package installs
   :warnings                show simulation warnings
   :reload                  re-read and re-process the Dockerfile
+  :mounts                  list volume mount shadows (Compose mode)
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
@@ -136,6 +137,14 @@ mod tests {
         assert!(
             run().contains(":reload"),
             "output must mention ':reload' in the custom commands section"
+        );
+    }
+
+    #[test]
+    fn help_contains_mounts() {
+        assert!(
+            run().contains(":mounts"),
+            "output must mention ':mounts' in the custom commands section"
         );
     }
 }

--- a/src/repl/custom/mod.rs
+++ b/src/repl/custom/mod.rs
@@ -11,4 +11,5 @@ pub mod explain;
 pub mod history;
 pub mod installed;
 pub mod layers;
+pub mod mounts;
 pub mod reload;

--- a/src/repl/custom/mounts.rs
+++ b/src/repl/custom/mounts.rs
@@ -1,0 +1,183 @@
+// `:mounts` command — list all volume mount shadows applied by the Compose engine.
+//
+// In Compose mode, `run_compose` populates `state.mounts` with one `MountInfo`
+// per volume entry declared in the selected service.  This command renders that
+// list in a compact, terminal-friendly format:
+//
+//   Mount shadows (2 total):
+//     /data           bind mount from ./data  [rw]
+//     /root/.npm      named volume: npm-cache  [ro]
+//
+// When no mounts have been recorded (e.g. in plain Dockerfile mode or when the
+// Compose service declares no volumes), a brief sentinel line is printed.
+
+use std::io::Write;
+
+use crate::model::state::PreviewState;
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::error::ReplError;
+
+/// Execute the `:mounts` command.
+///
+/// Writes a formatted list of all volume mount shadows to `writer`.
+/// When `state.mounts` is empty, prints `"No mount shadows recorded."`.
+pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: ":mounts".to_string(),
+        message: e.to_string(),
+    };
+
+    if state.mounts.is_empty() {
+        writeln!(writer, "No mount shadows recorded.").map_err(io_err)?;
+        return Ok(());
+    }
+
+    writeln!(writer, "Mount shadows ({} total):", state.mounts.len()).map_err(io_err)?;
+
+    for mount in &state.mounts {
+        // Sanitize user-supplied data before writing to the terminal.
+        let safe_path = sanitize_for_terminal(&mount.container_path.display().to_string());
+        let safe_desc = sanitize_for_terminal(&mount.description);
+        let rw_label = if mount.read_only { "ro" } else { "rw" };
+
+        writeln!(writer, "  {safe_path}  {safe_desc}  [{rw_label}]").map_err(io_err)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::provenance::MountInfo;
+    use crate::model::state::PreviewState;
+    use std::path::PathBuf;
+
+    fn run(state: &PreviewState) -> String {
+        let mut buf = Vec::new();
+        execute(state, &mut buf).expect("mounts should not fail");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    // --- empty state ---
+
+    #[test]
+    fn empty_mounts_prints_sentinel() {
+        let state = PreviewState::default();
+        let out = run(&state);
+        assert_eq!(out.trim(), "No mount shadows recorded.", "got: {out}");
+    }
+
+    // --- single bind mount ---
+
+    #[test]
+    fn bind_mount_shows_container_path_and_description() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("/data"),
+            "must show container path; got: {out}"
+        );
+        assert!(
+            out.contains("bind mount from ./data"),
+            "must show description; got: {out}"
+        );
+        assert!(out.contains("[rw]"), "must show rw label; got: {out}");
+    }
+
+    // --- read-only mount ---
+
+    #[test]
+    fn read_only_mount_shows_ro_label() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/config"),
+            read_only: true,
+            description: "named volume: cfg".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("[ro]"),
+            "read-only mount must show [ro]; got: {out}"
+        );
+    }
+
+    // --- named volume ---
+
+    #[test]
+    fn named_volume_shows_volume_name_in_description() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/root/.npm"),
+            read_only: false,
+            description: "named volume: npm-cache".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("named volume: npm-cache"),
+            "must show named volume; got: {out}"
+        );
+    }
+
+    // --- anonymous volume ---
+
+    #[test]
+    fn anonymous_volume_shows_description() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/tmp/scratch"),
+            read_only: false,
+            description: "anonymous volume".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("anonymous volume"),
+            "must show anonymous volume; got: {out}"
+        );
+    }
+
+    // --- total count in header ---
+
+    #[test]
+    fn header_shows_correct_count() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
+        });
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/cache"),
+            read_only: false,
+            description: "named volume: cache".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("Mount shadows (2 total):"),
+            "header must show count; got: {out}"
+        );
+    }
+
+    // --- ANSI sanitization ---
+
+    #[test]
+    fn ansi_escape_in_description_is_stripped() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from \x1b[2J./data".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            !out.contains('\x1b'),
+            "ANSI escapes must be stripped; got: {out:?}"
+        );
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -27,7 +27,7 @@ use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
 use crate::repl::commands::{apt, cat, cd, env_cmd, find, help, ls, pip, pwd, which};
 use crate::repl::config::ReplConfig;
-use crate::repl::custom::{explain, history, installed, layers, reload};
+use crate::repl::custom::{explain, history, installed, layers, mounts, reload};
 use crate::repl::error::ReplError;
 use crate::repl::parse::{parse_input, ParsedCommand};
 
@@ -170,6 +170,9 @@ pub fn dispatch(
         }
         ParsedCommand::Explain { path } => {
             explain::execute(state, &path, writer)?;
+        }
+        ParsedCommand::Mounts => {
+            mounts::execute(state, writer)?;
         }
         ParsedCommand::Exit => {
             return Ok(false);

--- a/src/repl/parse.rs
+++ b/src/repl/parse.rs
@@ -63,6 +63,8 @@ pub enum ParsedCommand {
     },
     /// `:reload` — re-read and re-process the Dockerfile.
     Reload,
+    /// `:mounts` — list all volume mount shadows applied by the Compose engine.
+    Mounts,
     /// The input was empty or only whitespace.
     Empty,
     /// The input did not match any known command.
@@ -110,6 +112,7 @@ pub fn parse_input(line: &str) -> ParsedCommand {
         ":history" => ParsedCommand::History,
         ":installed" => ParsedCommand::Installed,
         ":reload" => ParsedCommand::Reload,
+        ":mounts" => ParsedCommand::Mounts,
         _ => ParsedCommand::Unknown {
             input: trimmed.to_string(),
         },
@@ -812,6 +815,29 @@ mod tests {
             parse_input("WHICH curl"),
             ParsedCommand::Unknown {
                 input: "WHICH curl".to_string()
+            }
+        );
+    }
+
+    // --- :mounts ---
+
+    #[test]
+    fn mounts_bare_returns_mounts() {
+        assert_eq!(parse_input(":mounts"), ParsedCommand::Mounts);
+    }
+
+    #[test]
+    fn mounts_with_trailing_whitespace_returns_mounts() {
+        assert_eq!(parse_input(":mounts  "), ParsedCommand::Mounts);
+    }
+
+    #[test]
+    fn mounts_uppercase_is_unknown() {
+        // Custom commands are case-sensitive — :MOUNTS is not :mounts.
+        assert_eq!(
+            parse_input(":MOUNTS"),
+            ParsedCommand::Unknown {
+                input: ":MOUNTS".to_string()
             }
         );
     }


### PR DESCRIPTION
## Summary

- **Restructures `MountInfo`** — replaces the old `source: String` + `mount_type: MountKind` fields with `container_path: PathBuf`, `read_only: bool`, and `description: String` (pre-formatted, sanitized). `MountKind` is removed.
- **`VirtualFs::get_mut` + `FsNode::provenance_mut`** — enable in-place provenance annotation without re-inserting nodes.
- **`PreviewState.mounts: Vec<MountInfo>`** — stores all mount shadows for the `:mounts` command.
- **`engine/mount.rs`** — `apply_mount_shadows` converts each `VolumeSpec` into `MountInfo`, attaches it to existing FS nodes, and records it in `state.mounts`. Called at the end of `run_compose`.
- **`:mounts` REPL command** — lists all volume mount shadows with container path, description, and `[rw/ro]` label.

## Test plan

- [x] `cargo build` passes clean
- [x] `cargo clippy -- -D warnings` passes clean
- [x] All 714 tests pass (650 lib + 64 integration)
- [x] New tests in `engine/mount.rs`: 12 unit tests covering bind/named/anonymous specs, read-only flag, FS node shadowing, nonexistent paths, multiple volumes
- [x] New tests in `repl/custom/mounts.rs`: 8 unit tests covering empty state, bind/named/anonymous display, ro label, count header, ANSI sanitization
- [x] New tests in `repl/parse.rs`: 3 tests for `:mounts` parsing
- [x] New tests in `engine/compose.rs`: 2 integration tests verifying mount shadows flow through `run_compose`

Closes #51