### PR TITLE
feat: REPL Compose commands :services, :mounts guard, :depends (#52)

### DIFF
--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -39,6 +39,8 @@ CUSTOM COMMANDS (prefix with :)
   :warnings                show simulation warnings
   :reload                  re-read and re-process the Dockerfile
   :mounts                  list volume mount shadows (Compose mode)
+  :services                list all Compose services (Compose mode)
+  :depends                 show dependency tree (Compose mode)
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
@@ -145,6 +147,22 @@ mod tests {
         assert!(
             run().contains(":mounts"),
             "output must mention ':mounts' in the custom commands section"
+        );
+    }
+
+    #[test]
+    fn help_contains_services() {
+        assert!(
+            run().contains(":services"),
+            "output must mention ':services' in the custom commands section"
+        );
+    }
+
+    #[test]
+    fn help_contains_depends() {
+        assert!(
+            run().contains(":depends"),
+            "output must mention ':depends' in the custom commands section"
         );
     }
 }

--- a/src/repl/custom/depends.rs
+++ b/src/repl/custom/depends.rs
@@ -1,0 +1,341 @@
+// `:depends` command — render the dependency tree for the selected service.
+//
+// In Compose mode, performs a depth-first traversal of `depends_on` starting
+// from the selected service and prints an indented tree:
+//
+//   api
+//     └─ db
+//     └─ redis
+//
+// Cycles are detected via a visited set. When a cycle is found, traversal
+// stops at that edge and a `[cycle detected]` marker is appended inline.
+//
+// In single-Dockerfile mode (no ComposeContext), prints a clear usage hint.
+
+use std::collections::HashSet;
+use std::io::Write;
+
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::config::ComposeContext;
+use crate::repl::error::ReplError;
+
+/// Guard message printed when `:depends` is invoked outside Compose mode.
+const GUARD_MSG: &str = "\
+:depends is only available in compose mode
+  Usage: demu --compose -f compose.yaml --service <name>
+";
+
+/// Execute the `:depends` command.
+///
+/// When `ctx` is `None` the guard message is printed.
+/// When `ctx` is `Some`, a dependency tree is rendered starting from
+/// `ctx.selected_service`.
+pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: ":depends".to_string(),
+        message: e.to_string(),
+    };
+
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            write!(writer, "{GUARD_MSG}").map_err(io_err)?;
+            return Ok(());
+        }
+    };
+
+    let root = &ctx.selected_service;
+    let services = &ctx.compose_file.services;
+
+    // Print root service.
+    let safe_root = sanitize_for_terminal(root);
+    writeln!(writer, "{safe_root}").map_err(io_err)?;
+
+    // DFS traversal with a visited set to detect cycles.
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(root.clone());
+
+    // Collect immediate dependencies of root, in original order.
+    if let Some(svc) = services.get(root) {
+        for dep in &svc.depends_on {
+            print_dep_tree(dep, services, &mut visited, 1, writer, &io_err)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Recursively print one level of the dependency tree.
+///
+/// `depth` controls the indentation level (1 = first level of children).
+/// `visited` carries the path from the root to detect cycles.
+fn print_dep_tree(
+    name: &str,
+    services: &std::collections::BTreeMap<String, crate::model::compose::Service>,
+    visited: &mut HashSet<String>,
+    depth: usize,
+    writer: &mut impl Write,
+    io_err: &impl Fn(std::io::Error) -> ReplError,
+) -> Result<(), ReplError> {
+    let indent = "  ".repeat(depth);
+    let safe_name = sanitize_for_terminal(name);
+
+    if visited.contains(name) {
+        // Cycle detected — print the name with a marker, do not recurse.
+        writeln!(writer, "{indent}└─ {safe_name}  [cycle detected]").map_err(io_err)?;
+        return Ok(());
+    }
+
+    writeln!(writer, "{indent}└─ {safe_name}").map_err(io_err)?;
+
+    // Mark as visited for the sub-tree.
+    visited.insert(name.to_string());
+
+    // Recurse into this service's own dependencies.
+    if let Some(svc) = services.get(name) {
+        for dep in &svc.depends_on {
+            print_dep_tree(dep, services, visited, depth + 1, writer, io_err)?;
+        }
+    }
+
+    // Unmark when returning (allow the same service to appear in separate branches).
+    visited.remove(name);
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::compose::{ComposeFile, Service, VolumeDefinition};
+    use crate::repl::config::ComposeContext;
+    use std::collections::BTreeMap;
+
+    fn run(ctx: Option<&ComposeContext>) -> String {
+        let mut buf = Vec::new();
+        execute(ctx, &mut buf).expect("depends should not fail");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    fn bare_service(name: &str) -> Service {
+        Service {
+            name: name.to_string(),
+            build: None,
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        }
+    }
+
+    fn compose_with_services(services: Vec<Service>) -> ComposeFile {
+        let mut map = BTreeMap::new();
+        for svc in services {
+            map.insert(svc.name.clone(), svc);
+        }
+        ComposeFile {
+            services: map,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- guard mode ---
+
+    #[test]
+    fn no_context_prints_guard_message() {
+        let out = run(None);
+        assert!(
+            out.contains(":depends is only available in compose mode"),
+            "guard message missing; got: {out}"
+        );
+        assert!(
+            out.contains("--compose"),
+            "usage hint must mention --compose; got: {out}"
+        );
+    }
+
+    // --- leaf service (no dependencies) ---
+
+    #[test]
+    fn leaf_service_shows_root_only() {
+        let db = bare_service("db");
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![db]),
+            selected_service: "db".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.trim() == "db",
+            "leaf service should only print its name; got: {out}"
+        );
+    }
+
+    // --- service with one dependency ---
+
+    #[test]
+    fn single_dependency_shows_tree_entry() {
+        let db = bare_service("db");
+        let api = Service {
+            depends_on: vec!["db".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.starts_with("api\n"),
+            "root must be first line; got: {out}"
+        );
+        assert!(
+            out.contains("└─ db"),
+            "dependency must appear as tree entry; got: {out}"
+        );
+    }
+
+    // --- service with two dependencies ---
+
+    #[test]
+    fn two_dependencies_both_appear() {
+        let db = bare_service("db");
+        let redis = bare_service("redis");
+        let api = Service {
+            depends_on: vec!["db".to_string(), "redis".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db, redis]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("└─ db"), "db must appear; got: {out}");
+        assert!(out.contains("└─ redis"), "redis must appear; got: {out}");
+    }
+
+    // --- multi-level tree ---
+
+    #[test]
+    fn multi_level_tree_indented_correctly() {
+        // api → db → cache (3 levels)
+        let cache = bare_service("cache");
+        let db = Service {
+            depends_on: vec!["cache".to_string()],
+            image: Some("postgres".to_string()),
+            ..bare_service("db")
+        };
+        let api = Service {
+            depends_on: vec!["db".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, cache, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.starts_with("api"), "root first; got: {out}");
+        assert!(out.contains("└─ db"), "first level; got: {out}");
+        // cache must appear indented at a deeper level than db
+        let db_pos = out.find("└─ db").expect("db must be present");
+        let cache_pos = out.find("└─ cache").expect("cache must be present");
+        assert!(
+            cache_pos > db_pos,
+            "cache must appear after db; got:\n{out}"
+        );
+    }
+
+    // --- cycle detection ---
+
+    #[test]
+    fn cycle_is_detected_and_marked() {
+        // a → b → a (cycle)
+        let a = Service {
+            depends_on: vec!["b".to_string()],
+            image: Some("img".to_string()),
+            ..bare_service("a")
+        };
+        let b = Service {
+            depends_on: vec!["a".to_string()],
+            image: Some("img".to_string()),
+            ..bare_service("b")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![a, b]),
+            selected_service: "a".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.contains("[cycle detected]"),
+            "cycle must be marked; got: {out}"
+        );
+    }
+
+    // --- same service appears in multiple branches (diamond pattern) ---
+
+    #[test]
+    fn diamond_dependency_not_false_cycle() {
+        // api → db AND api → cache; both → shared (diamond, not a cycle)
+        let shared = bare_service("shared");
+        let db = Service {
+            depends_on: vec!["shared".to_string()],
+            image: Some("postgres".to_string()),
+            ..bare_service("db")
+        };
+        let cache = Service {
+            depends_on: vec!["shared".to_string()],
+            image: Some("redis".to_string()),
+            ..bare_service("cache")
+        };
+        let api = Service {
+            depends_on: vec!["db".to_string(), "cache".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, cache, db, shared]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        // shared should appear twice (once under db, once under cache) — NOT flagged as cycle
+        let shared_count = out.matches("└─ shared").count();
+        assert_eq!(
+            shared_count, 2,
+            "shared should appear twice in diamond; got:\n{out}"
+        );
+        assert!(
+            !out.contains("[cycle detected]"),
+            "diamond pattern must not trigger cycle detection; got:\n{out}"
+        );
+    }
+
+    // --- ANSI sanitization ---
+
+    #[test]
+    fn ansi_escape_in_service_name_is_stripped() {
+        let evil_dep = Service {
+            image: Some("img".to_string()),
+            ..bare_service("dep\x1b[2J")
+        };
+        let api = Service {
+            depends_on: vec!["dep\x1b[2J".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, evil_dep]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            !out.contains('\x1b'),
+            "ANSI escapes must be stripped; got: {out:?}"
+        );
+    }
+}

--- a/src/repl/custom/mod.rs
+++ b/src/repl/custom/mod.rs
@@ -7,9 +7,11 @@
 // `reload` is the only handler here that mutates `PreviewState`; all others
 // are pure read commands.
 
+pub mod depends;
 pub mod explain;
 pub mod history;
 pub mod installed;
 pub mod layers;
 pub mod mounts;
 pub mod reload;
+pub mod services;

--- a/src/repl/custom/mounts.rs
+++ b/src/repl/custom/mounts.rs
@@ -8,24 +8,39 @@
 //     /data           bind mount from ./data  [rw]
 //     /root/.npm      named volume: npm-cache  [ro]
 //
-// When no mounts have been recorded (e.g. in plain Dockerfile mode or when the
-// Compose service declares no volumes), a brief sentinel line is printed.
+// In single-Dockerfile mode (no ComposeContext), prints a clear usage hint.
 
 use std::io::Write;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::config::ComposeContext;
 use crate::repl::error::ReplError;
+
+/// Guard message printed when `:mounts` is invoked outside Compose mode.
+const GUARD_MSG: &str = "\
+:mounts is only available in compose mode
+  Usage: demu --compose -f compose.yaml --service <name>
+";
 
 /// Execute the `:mounts` command.
 ///
-/// Writes a formatted list of all volume mount shadows to `writer`.
-/// When `state.mounts` is empty, prints `"No mount shadows recorded."`.
-pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
+/// When `compose_ctx` is `None` the guard message is printed.
+/// Otherwise, writes a formatted list of all volume mount shadows to `writer`.
+pub fn execute(
+    state: &PreviewState,
+    compose_ctx: Option<&ComposeContext>,
+    writer: &mut impl Write,
+) -> Result<(), ReplError> {
     let io_err = |e: std::io::Error| ReplError::InvalidArguments {
         command: ":mounts".to_string(),
         message: e.to_string(),
     };
+
+    if compose_ctx.is_none() {
+        write!(writer, "{GUARD_MSG}").map_err(io_err)?;
+        return Ok(());
+    }
 
     if state.mounts.is_empty() {
         writeln!(writer, "No mount shadows recorded.").map_err(io_err)?;
@@ -50,22 +65,48 @@ pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), Repl
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::model::compose::ComposeFile;
     use crate::model::provenance::MountInfo;
     use crate::model::state::PreviewState;
+    use crate::repl::config::ComposeContext;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    fn run(state: &PreviewState) -> String {
+    fn dummy_ctx() -> ComposeContext {
+        ComposeContext {
+            compose_file: ComposeFile {
+                services: BTreeMap::new(),
+                volumes: BTreeMap::new(),
+            },
+            selected_service: "svc".to_string(),
+        }
+    }
+
+    fn run(state: &PreviewState, ctx: Option<&ComposeContext>) -> String {
         let mut buf = Vec::new();
-        execute(state, &mut buf).expect("mounts should not fail");
+        execute(state, ctx, &mut buf).expect("mounts should not fail");
         String::from_utf8(buf).expect("utf-8")
+    }
+
+    // --- guard mode ---
+
+    #[test]
+    fn no_context_prints_guard_message() {
+        let state = PreviewState::default();
+        let out = run(&state, None);
+        assert!(
+            out.contains(":mounts is only available in compose mode"),
+            "guard message missing; got: {out}"
+        );
     }
 
     // --- empty state ---
 
     #[test]
     fn empty_mounts_prints_sentinel() {
+        let ctx = dummy_ctx();
         let state = PreviewState::default();
-        let out = run(&state);
+        let out = run(&state, Some(&ctx));
         assert_eq!(out.trim(), "No mount shadows recorded.", "got: {out}");
     }
 
@@ -79,7 +120,8 @@ mod tests {
             read_only: false,
             description: "bind mount from ./data".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("/data"),
             "must show container path; got: {out}"
@@ -101,7 +143,8 @@ mod tests {
             read_only: true,
             description: "named volume: cfg".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("[ro]"),
             "read-only mount must show [ro]; got: {out}"
@@ -118,7 +161,8 @@ mod tests {
             read_only: false,
             description: "named volume: npm-cache".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("named volume: npm-cache"),
             "must show named volume; got: {out}"
@@ -135,7 +179,8 @@ mod tests {
             read_only: false,
             description: "anonymous volume".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("anonymous volume"),
             "must show anonymous volume; got: {out}"
@@ -157,7 +202,8 @@ mod tests {
             read_only: false,
             description: "named volume: cache".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("Mount shadows (2 total):"),
             "header must show count; got: {out}"
@@ -174,7 +220,8 @@ mod tests {
             read_only: false,
             description: "bind mount from \x1b[2J./data".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             !out.contains('\x1b'),
             "ANSI escapes must be stripped; got: {out:?}"

--- a/src/repl/custom/services.rs
+++ b/src/repl/custom/services.rs
@@ -1,0 +1,293 @@
+// `:services` command — list all services in the Compose file.
+//
+// In Compose mode, shows a table of all services with their type (build vs
+// image) and their `depends_on` list. The currently selected service is
+// prefixed with `*`.
+//
+// In single-Dockerfile mode (no ComposeContext), prints a clear usage hint
+// so the user knows how to invoke Compose mode.
+//
+// Example output (Compose mode with 3 services, "api" selected):
+//
+//   Services (3 total):
+//   * api     build: Dockerfile   depends: db, redis
+//     db      image: postgres:15
+//     redis   image: redis:7
+//
+// Column widths are derived from the longest name to keep columns aligned.
+
+use std::io::Write;
+
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::config::ComposeContext;
+use crate::repl::error::ReplError;
+
+/// Guard message printed when `:services` is invoked outside Compose mode.
+const GUARD_MSG: &str = "\
+:services is only available in compose mode
+  Usage: demu --compose -f compose.yaml --service <name>
+";
+
+/// Execute the `:services` command.
+///
+/// When `ctx` is `None` the guard message is printed.
+/// When `ctx` is `Some`, a formatted service table is printed.
+pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: ":services".to_string(),
+        message: e.to_string(),
+    };
+
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            write!(writer, "{GUARD_MSG}").map_err(io_err)?;
+            return Ok(());
+        }
+    };
+
+    let services = &ctx.compose_file.services;
+    let selected = &ctx.selected_service;
+
+    // Determine column width from the longest service name (min 8 chars).
+    let name_width = services.keys().map(|k| k.len()).max().unwrap_or(0).max(8);
+
+    writeln!(writer, "Services ({} total):", services.len()).map_err(io_err)?;
+
+    // BTreeMap iterates in sorted order, which keeps output deterministic.
+    for (name, svc) in services {
+        let prefix = if name == selected { '*' } else { ' ' };
+
+        // Build type description: "build: <dockerfile>" or "image: <image>".
+        let type_str = match (&svc.build, &svc.image) {
+            (Some(build), _) => {
+                let df = sanitize_for_terminal(&build.dockerfile.display().to_string());
+                format!("build: {df}")
+            }
+            (None, Some(image)) => {
+                let safe = sanitize_for_terminal(image);
+                format!("image: {safe}")
+            }
+            (None, None) => "image: <unknown>".to_string(),
+        };
+
+        // Build depends_on string: "depends: a, b" or empty.
+        let depends_str = if svc.depends_on.is_empty() {
+            String::new()
+        } else {
+            let names: Vec<String> = svc
+                .depends_on
+                .iter()
+                .map(|d| sanitize_for_terminal(d))
+                .collect();
+            format!("  depends: {}", names.join(", "))
+        };
+
+        let safe_name = sanitize_for_terminal(name);
+        writeln!(
+            writer,
+            "{prefix} {safe_name:<name_width$}  {type_str}{depends_str}"
+        )
+        .map_err(io_err)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::compose::{BuildConfig, ComposeFile, Service, VolumeDefinition};
+    use crate::repl::config::ComposeContext;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn run(ctx: Option<&ComposeContext>) -> String {
+        let mut buf = Vec::new();
+        execute(ctx, &mut buf).expect("services should not fail");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    fn bare_service(name: &str) -> Service {
+        Service {
+            name: name.to_string(),
+            build: None,
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        }
+    }
+
+    fn compose_with_services(services: Vec<Service>) -> ComposeFile {
+        let mut map = BTreeMap::new();
+        for svc in services {
+            map.insert(svc.name.clone(), svc);
+        }
+        ComposeFile {
+            services: map,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- guard mode ---
+
+    #[test]
+    fn no_context_prints_guard_message() {
+        let out = run(None);
+        assert!(
+            out.contains(":services is only available in compose mode"),
+            "guard message missing; got: {out}"
+        );
+        assert!(
+            out.contains("--compose"),
+            "usage hint must mention --compose; got: {out}"
+        );
+    }
+
+    // --- service type: image ---
+
+    #[test]
+    fn image_only_service_shows_image_label() {
+        let svc = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![svc]),
+            selected_service: "db".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("image: postgres:15"), "got: {out}");
+    }
+
+    // --- service type: build ---
+
+    #[test]
+    fn build_service_shows_dockerfile_name() {
+        let svc = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![svc]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("build: Dockerfile"), "got: {out}");
+    }
+
+    // --- selected service is marked with * ---
+
+    #[test]
+    fn selected_service_is_marked_with_asterisk() {
+        let api = Service {
+            image: Some("nginx".to_string()),
+            ..bare_service("api")
+        };
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        // "* api" must appear in the output.
+        assert!(
+            out.contains("* api"),
+            "selected service must have * prefix; got:\n{out}"
+        );
+        // "  db" (with space prefix) must appear.
+        assert!(
+            out.contains("  db"),
+            "non-selected service must have space prefix; got:\n{out}"
+        );
+    }
+
+    // --- depends_on is listed ---
+
+    #[test]
+    fn depends_on_appears_in_output() {
+        let api = Service {
+            image: Some("myapp".to_string()),
+            depends_on: vec!["db".to_string(), "redis".to_string()],
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("depends: db, redis"), "got: {out}");
+    }
+
+    // --- service with no depends_on shows no depends label ---
+
+    #[test]
+    fn no_depends_on_shows_no_depends_label() {
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![db]),
+            selected_service: "db".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            !out.contains("depends:"),
+            "no depends_on must not show label; got:\n{out}"
+        );
+    }
+
+    // --- header shows total count ---
+
+    #[test]
+    fn header_shows_service_count() {
+        let api = Service {
+            image: Some("nginx".to_string()),
+            ..bare_service("api")
+        };
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.contains("Services (2 total):"),
+            "header missing; got: {out}"
+        );
+    }
+
+    // --- ANSI sanitization ---
+
+    #[test]
+    fn ansi_escape_in_service_name_is_stripped() {
+        let evil = Service {
+            image: Some("postgres".to_string()),
+            ..bare_service("db\x1b[2J")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![evil]),
+            selected_service: "db\x1b[2J".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            !out.contains('\x1b'),
+            "ANSI escapes must be stripped; got: {out:?}"
+        );
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -26,8 +26,8 @@ use rustyline::DefaultEditor;
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
 use crate::repl::commands::{apt, cat, cd, env_cmd, find, help, ls, pip, pwd, which};
-use crate::repl::config::ReplConfig;
-use crate::repl::custom::{explain, history, installed, layers, mounts, reload};
+use crate::repl::config::{ComposeContext, ReplConfig};
+use crate::repl::custom::{depends, explain, history, installed, layers, mounts, reload, services};
 use crate::repl::error::ReplError;
 use crate::repl::parse::{parse_input, ParsedCommand};
 
@@ -76,7 +76,7 @@ pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result
                     continue;
                 }
 
-                match dispatch(state, cmd, &mut out) {
+                match dispatch(state, cmd, config.compose_context.as_ref(), &mut out) {
                     // `exit` / `quit` — terminate the loop cleanly.
                     Ok(false) => break,
                     Ok(true) => {}
@@ -116,6 +116,11 @@ pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result
 /// All handlers write their output to `writer` rather than to stdout, which
 /// makes this function fully testable without capturing stdout.
 ///
+/// `compose_ctx` is `Some` when the REPL session was started in Compose mode
+/// (`--compose`). Compose-mode commands (`:services`, `:mounts`, `:depends`)
+/// use this to access the parsed Compose file and selected service. When
+/// `compose_ctx` is `None`, those commands print a usage hint.
+///
 /// Returns `Ok(true)` normally or `Ok(false)` when the command signals exit.
 /// The caller is responsible for exiting the loop on `Exit`.
 ///
@@ -126,6 +131,7 @@ pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result
 pub fn dispatch(
     state: &mut PreviewState,
     cmd: ParsedCommand,
+    compose_ctx: Option<&ComposeContext>,
     writer: &mut impl Write,
 ) -> Result<bool, ReplError> {
     match cmd {
@@ -172,7 +178,13 @@ pub fn dispatch(
             explain::execute(state, &path, writer)?;
         }
         ParsedCommand::Mounts => {
-            mounts::execute(state, writer)?;
+            mounts::execute(state, compose_ctx, writer)?;
+        }
+        ParsedCommand::Services => {
+            services::execute(compose_ctx, writer)?;
+        }
+        ParsedCommand::Depends => {
+            depends::execute(compose_ctx, writer)?;
         }
         ParsedCommand::Exit => {
             return Ok(false);
@@ -224,7 +236,10 @@ mod tests {
     fn dispatch_str(state: &mut PreviewState, input: &str) -> Result<(bool, String), ReplError> {
         let cmd = parse_input(input);
         let mut buf = Vec::new();
-        let cont = dispatch(state, cmd, &mut buf)?;
+        // Pass None for compose_ctx — all standard REPL tests operate in
+        // single-Dockerfile mode. Compose-mode command tests live in
+        // the respective custom module test suites.
+        let cont = dispatch(state, cmd, None, &mut buf)?;
         Ok((cont, String::from_utf8(buf).expect("utf-8")))
     }
 
@@ -326,7 +341,7 @@ mod tests {
         let mut state = PreviewState::default();
         let cmd = ParsedCommand::Exit;
         let mut buf = Vec::new();
-        let cont = dispatch(&mut state, cmd, &mut buf).expect("should succeed");
+        let cont = dispatch(&mut state, cmd, None, &mut buf).expect("should succeed");
         assert!(!cont, "exit must return false to signal loop termination");
     }
 

--- a/src/repl/parse.rs
+++ b/src/repl/parse.rs
@@ -65,6 +65,10 @@ pub enum ParsedCommand {
     Reload,
     /// `:mounts` — list all volume mount shadows applied by the Compose engine.
     Mounts,
+    /// `:services` — list all services in the Compose file (Compose mode only).
+    Services,
+    /// `:depends` — render the dependency tree for the selected service (Compose mode only).
+    Depends,
     /// The input was empty or only whitespace.
     Empty,
     /// The input did not match any known command.
@@ -113,6 +117,8 @@ pub fn parse_input(line: &str) -> ParsedCommand {
         ":installed" => ParsedCommand::Installed,
         ":reload" => ParsedCommand::Reload,
         ":mounts" => ParsedCommand::Mounts,
+        ":services" => ParsedCommand::Services,
+        ":depends" => ParsedCommand::Depends,
         _ => ParsedCommand::Unknown {
             input: trimmed.to_string(),
         },
@@ -815,6 +821,50 @@ mod tests {
             parse_input("WHICH curl"),
             ParsedCommand::Unknown {
                 input: "WHICH curl".to_string()
+            }
+        );
+    }
+
+    // --- :services ---
+
+    #[test]
+    fn services_bare_returns_services() {
+        assert_eq!(parse_input(":services"), ParsedCommand::Services);
+    }
+
+    #[test]
+    fn services_with_trailing_whitespace_returns_services() {
+        assert_eq!(parse_input(":services  "), ParsedCommand::Services);
+    }
+
+    #[test]
+    fn services_uppercase_is_unknown() {
+        assert_eq!(
+            parse_input(":SERVICES"),
+            ParsedCommand::Unknown {
+                input: ":SERVICES".to_string()
+            }
+        );
+    }
+
+    // --- :depends ---
+
+    #[test]
+    fn depends_bare_returns_depends() {
+        assert_eq!(parse_input(":depends"), ParsedCommand::Depends);
+    }
+
+    #[test]
+    fn depends_with_trailing_whitespace_returns_depends() {
+        assert_eq!(parse_input(":depends  "), ParsedCommand::Depends);
+    }
+
+    #[test]
+    fn depends_uppercase_is_unknown() {
+        assert_eq!(
+            parse_input(":DEPENDS"),
+            ParsedCommand::Unknown {
+                input: ":DEPENDS".to_string()
             }
         );
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,14 +4,14 @@ Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
 Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
-- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
+- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Up next
-- [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
-- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 
+- [x] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model — merged [#58](https://github.com/automatedtomato/demu/pull/58)
+- [x] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge — merged [#57](https://github.com/automatedtomato/demu/pull/57)
 - [x] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags — merged [#56](https://github.com/automatedtomato/demu/pull/56)
 - [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — merged [#53](https://github.com/automatedtomato/demu/pull/53)
 - [x] [#42](https://github.com/automatedtomato/demu/issues/42) feat: `COPY --from=<stage>` cross-stage file copying — merged [#45](https://github.com/automatedtomato/demu/pull/45)


### PR DESCRIPTION
## Summary

- **`dispatch()` now accepts `Option<&ComposeContext>`** — Compose-mode commands show a clear usage hint in single-Dockerfile mode instead of failing silently
- **`:mounts` guard** — prints `:mounts is only available in compose mode / Usage: demu --compose -f compose.yaml --service <name>` when not in Compose mode
- **New `:services` command** — lists all Compose services (alphabetical order), marks the selected service with `*`, shows `build: <dockerfile>` or `image: <name>`, and lists `depends_on`
- **New `:depends` command** — renders a DFS dependency tree from the selected service; cycle edges are marked with `[cycle detected]`; diamond/shared dependencies appear in multiple branches without false cycle detection (visited set is removed on backtrack)

## Test plan

- [x] `cargo build` passes clean
- [x] `cargo clippy -- -D warnings` passes clean  
- [x] 676 lib tests pass, 49 integration tests pass
- [x] `:services` tests: guard mode, image-only service, build service, selected marker `*`, depends_on, no depends_on, header count, ANSI sanitization (9 tests)
- [x] `:depends` tests: guard mode, leaf service, single dep, two deps, multi-level indentation, cycle detection, diamond pattern (not a false cycle), ANSI sanitization (8 tests)
- [x] `:mounts` guard test added
- [x] parse tests for `:services` and `:depends` (6 tests)
- [x] help text tests for `:services` and `:depends`

Closes #52