### PR TITLE
fix: warn when --service is used without --compose (#66)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,12 @@ fn run_cli() -> Result<()> {
         return run_compose_pipeline(&cli);
     }
 
+    // Warn if --service was passed without --compose. The flag is silently
+    // ignored in Dockerfile mode, which would be very confusing to the user.
+    if cli.service.is_some() {
+        eprintln!("demu: warning: --service is only valid with --compose; ignoring");
+    }
+
     // ── 1. Validate the path ─────────────────────────────────────────────────
 
     // The path must exist — surface a clear error rather than a confusing I/O

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn run_cli() -> Result<()> {
     // Warn if --service was passed without --compose. The flag is silently
     // ignored in Dockerfile mode, which would be very confusing to the user.
     if cli.service.is_some() {
-        eprintln!("demu: warning: --service is only valid with --compose; ignoring");
+        eprintln!("warning: --service is only valid with --compose; ignoring");
     }
 
     // ── 1. Validate the path ─────────────────────────────────────────────────

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -490,6 +490,39 @@ fn dockerfile_pipeline_unchanged_after_compose_addition() {
     );
 }
 
+// ── test 16: --service without --compose emits warning but still exits 0 ──────
+
+#[test]
+fn service_without_compose_emits_warning() {
+    // Passing --service without --compose should not abort, but should emit
+    // a clear warning to stderr so the user is not silently misled.
+    let dockerfile = temp_dockerfile("FROM scratch\n");
+
+    let output = demu()
+        .args([
+            "-f",
+            dockerfile.path().to_str().expect("path"),
+            "--service",
+            "api",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert!(
+        output.status.success(),
+        "--service without --compose must still exit 0; got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning"),
+        "--service without --compose must emit a warning to stderr; got: {stderr}"
+    );
+}
+
 // ── test 11 (original): empty Dockerfile (no instructions) exits 0 ───────────
 
 #[test]

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -518,8 +518,12 @@ fn service_without_compose_emits_warning() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
+        stderr.contains("--service"),
+        "--service without --compose must mention '--service' in the warning; got: {stderr}"
+    );
+    assert!(
         stderr.contains("warning"),
-        "--service without --compose must emit a warning to stderr; got: {stderr}"
+        "--service without --compose must be prefixed with 'warning'; got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

When a user passes `--service api -f Dockerfile` (without `--compose`), demu now emits a warning to stderr before running the Dockerfile pipeline:

```
demu: warning: --service is only valid with --compose; ignoring
```

Previously the flag was silently discarded. A user who accidentally omitted `--compose` would see normal Dockerfile output with no indication that `--service` was ignored.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] Integration test `service_without_compose_emits_warning` — verifies exit code 0 and warning in stderr
- [x] Full integration suite (17 tests) passes

Closes #66