### PR TITLE
fix(repl): introduce ReplError::Io for terminal write failures (#65)

### DIFF
--- a/src/repl/commands/cat.rs
+++ b/src/repl/commands/cat.rs
@@ -36,7 +36,7 @@ pub fn execute(state: &PreviewState, path: &str, writer: &mut impl Write) -> Res
             // Use lossy conversion so non-UTF-8 bytes are displayed as U+FFFD
             // rather than causing a panic or hard error.
             let content = String::from_utf8_lossy(&f.content);
-            write!(writer, "{content}").map_err(|e| ReplError::InvalidArguments {
+            write!(writer, "{content}").map_err(|e| ReplError::Io {
                 command: "cat".to_string(),
                 message: e.to_string(),
             })
@@ -54,11 +54,9 @@ pub fn execute(state: &PreviewState, path: &str, writer: &mut impl Write) -> Res
             } else {
                 " (symlink, follow manually)"
             };
-            writeln!(writer, "-> {}{note}", s.target.display()).map_err(|e| {
-                ReplError::InvalidArguments {
-                    command: "cat".to_string(),
-                    message: e.to_string(),
-                }
+            writeln!(writer, "-> {}{note}", s.target.display()).map_err(|e| ReplError::Io {
+                command: "cat".to_string(),
+                message: e.to_string(),
             })
         }
         None => Err(ReplError::PathNotFound { path: resolved }),

--- a/src/repl/commands/find.rs
+++ b/src/repl/commands/find.rs
@@ -64,7 +64,7 @@ pub fn execute(
     matches.sort();
 
     for m in &matches {
-        writeln!(writer, "{m}").map_err(|e| ReplError::InvalidArguments {
+        writeln!(writer, "{m}").map_err(|e| ReplError::Io {
             command: "find".to_string(),
             message: e.to_string(),
         })?;

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -44,7 +44,7 @@ CUSTOM COMMANDS (prefix with :)
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
-    write!(writer, "{help_text}").map_err(|e| ReplError::InvalidArguments {
+    write!(writer, "{help_text}").map_err(|e| ReplError::Io {
         command: "help".to_string(),
         message: e.to_string(),
     })

--- a/src/repl/commands/ls.rs
+++ b/src/repl/commands/ls.rs
@@ -62,7 +62,7 @@ pub fn execute(
             .and_then(|n| n.to_str())
             .unwrap_or("?");
 
-        format_entry(name, node, long, writer).map_err(|e| ReplError::InvalidArguments {
+        format_entry(name, node, long, writer).map_err(|e| ReplError::Io {
             command: "ls".to_string(),
             message: e.to_string(),
         })?;

--- a/src/repl/commands/pwd.rs
+++ b/src/repl/commands/pwd.rs
@@ -14,7 +14,7 @@ use crate::repl::error::ReplError;
 /// followed by a newline. The command never fails.
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Display the cwd as a string; PathBuf::display() is safe on all platforms.
-    writeln!(writer, "{}", state.cwd.display()).map_err(|e| ReplError::InvalidArguments {
+    writeln!(writer, "{}", state.cwd.display()).map_err(|e| ReplError::Io {
         command: "pwd".to_string(),
         message: e.to_string(),
     })

--- a/src/repl/custom/depends.rs
+++ b/src/repl/custom/depends.rs
@@ -31,7 +31,7 @@ const GUARD_MSG: &str = "\
 /// When `ctx` is `Some`, a dependency tree is rendered starting from
 /// `ctx.selected_service`.
 pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":depends".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/history.rs
+++ b/src/repl/custom/history.rs
@@ -26,7 +26,7 @@ use crate::repl::error::ReplError;
 /// [`ReplError::InvalidArguments`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a ReplError so callers have a uniform error type.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":history".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/history.rs
+++ b/src/repl/custom/history.rs
@@ -23,7 +23,7 @@ use crate::repl::error::ReplError;
 /// message `"No history recorded."` is printed instead.
 ///
 /// All output goes to `writer`; I/O errors are mapped to
-/// [`ReplError::InvalidArguments`].
+/// [`ReplError::Io`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a ReplError so callers have a uniform error type.
     let io_err = |e: std::io::Error| ReplError::Io {

--- a/src/repl/custom/installed.rs
+++ b/src/repl/custom/installed.rs
@@ -36,7 +36,7 @@ const MANAGER_ORDER: &[&str] = &["apt", "pip", "npm", "apk", "go"];
 /// When no packages are recorded at all, prints `"No packages recorded."`.
 ///
 /// All output goes to `writer`; I/O errors are mapped to
-/// [`ReplError::InvalidArguments`].
+/// [`ReplError::Io`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a uniform ReplError.
     let io_err = io_err_mapper(":installed");

--- a/src/repl/custom/layers.rs
+++ b/src/repl/custom/layers.rs
@@ -30,7 +30,7 @@ use crate::repl::error::ReplError;
 /// [`ReplError::InvalidArguments`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a ReplError so callers have a uniform error type.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":layers".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/layers.rs
+++ b/src/repl/custom/layers.rs
@@ -27,7 +27,7 @@ use crate::repl::error::ReplError;
 /// instead.
 ///
 /// All output goes to `writer`; I/O errors are mapped to
-/// [`ReplError::InvalidArguments`].
+/// [`ReplError::Io`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a ReplError so callers have a uniform error type.
     let io_err = |e: std::io::Error| ReplError::Io {

--- a/src/repl/custom/mounts.rs
+++ b/src/repl/custom/mounts.rs
@@ -32,7 +32,7 @@ pub fn execute(
     compose_ctx: Option<&ComposeContext>,
     writer: &mut impl Write,
 ) -> Result<(), ReplError> {
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":mounts".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -5,7 +5,7 @@
 // - File read errors   → write message to err_writer, preserve old state, return Ok(())
 // - Parse errors       → write message to err_writer, preserve old state, return Ok(())
 // - Engine errors      → write message to err_writer, preserve old state, return Ok(())
-// - I/O write errors   → return Err(ReplError::InvalidArguments)
+// - I/O write errors   → return Err(ReplError::Io)
 //
 // On success, warnings from the new state are emitted to `err_writer` before
 // the confirmation message is written to `writer`.

--- a/src/repl/custom/services.rs
+++ b/src/repl/custom/services.rs
@@ -33,7 +33,7 @@ const GUARD_MSG: &str = "\
 /// When `ctx` is `None` the guard message is printed.
 /// When `ctx` is `Some`, a formatted service table is printed.
 pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":services".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/error.rs
+++ b/src/repl/error.rs
@@ -33,6 +33,13 @@ pub enum ReplError {
     #[error("{command}: {message}")]
     InvalidArguments { command: String, message: String },
 
+    /// A write to the output sink failed (e.g. broken pipe).
+    ///
+    /// Semantically distinct from [`InvalidArguments`]: this variant covers
+    /// I/O failures on the terminal writer, not user input errors.
+    #[error("{command}: output error: {message}")]
+    Io { command: String, message: String },
+
     /// The input did not match any known command.
     #[error("unknown command: '{input}'. Type 'help' for available commands.")]
     UnknownCommand { input: String },
@@ -56,7 +63,7 @@ pub enum ReplError {
 /// `command` and has no lifetime dependency on the original `&str`.
 pub fn io_err_mapper(command: &str) -> impl Fn(std::io::Error) -> ReplError {
     let command = command.to_owned();
-    move |e| ReplError::InvalidArguments {
+    move |e| ReplError::Io {
         command: command.clone(),
         message: e.to_string(),
     }
@@ -155,20 +162,20 @@ mod tests {
 
     // --- io_err_mapper ---
 
-    /// `io_err_mapper` must produce `ReplError::InvalidArguments` with the
-    /// exact command name and the I/O error message string.
+    /// `io_err_mapper` must produce `ReplError::Io` (not InvalidArguments) with
+    /// the exact command name and the I/O error message string.
     #[test]
-    fn io_err_mapper_produces_invalid_arguments_with_command_name() {
+    fn io_err_mapper_produces_io_error_with_command_name() {
         let mapper = io_err_mapper("test-cmd");
         let raw_err = io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe");
         let err = mapper(raw_err);
         assert_eq!(
             err,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: "test-cmd".to_string(),
                 message: "broken pipe".to_string(),
             },
-            "io_err_mapper must wrap the io::Error into InvalidArguments; got: {err:?}"
+            "io_err_mapper must wrap the io::Error into ReplError::Io; got: {err:?}"
         );
     }
 
@@ -180,14 +187,14 @@ mod tests {
         let e2 = mapper(io::Error::new(io::ErrorKind::Other, "second"));
         assert_eq!(
             e1,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: "multi".to_string(),
                 message: "first".to_string(),
             }
         );
         assert_eq!(
             e2,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: "multi".to_string(),
                 message: "second".to_string(),
             }
@@ -200,11 +207,40 @@ mod tests {
         let err = io_err_mapper(":reload")(io::Error::new(io::ErrorKind::Other, "oops"));
         assert_eq!(
             err,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: ":reload".to_string(),
                 message: "oops".to_string(),
             },
             "colon-prefixed command name must be preserved; got: {err:?}"
         );
+    }
+
+    // --- Io variant ---
+
+    #[test]
+    fn io_variant_display_contains_command_and_message() {
+        let err = ReplError::Io {
+            command: ":mounts".to_string(),
+            message: "broken pipe".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains(":mounts"), "must contain command; got: {msg}");
+        assert!(
+            msg.contains("broken pipe"),
+            "must contain message; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn io_variant_equality() {
+        let a = ReplError::Io {
+            command: "x".to_string(),
+            message: "y".to_string(),
+        };
+        let b = ReplError::Io {
+            command: "x".to_string(),
+            message: "y".to_string(),
+        };
+        assert_eq!(a, b);
     }
 }

--- a/src/repl/error.rs
+++ b/src/repl/error.rs
@@ -46,7 +46,7 @@ pub enum ReplError {
 }
 
 /// Returns a closure that maps a [`std::io::Error`] into
-/// [`ReplError::InvalidArguments`] for the given command name.
+/// [`ReplError::Io`] for the given command name.
 ///
 /// This is a shared helper so that command handlers do not each have to
 /// define the same 3-line inline closure. Use it wherever a `writeln!` or


### PR DESCRIPTION
## Summary

- Adds a dedicated `ReplError::Io { command, message }` variant to `repl/error.rs` that is semantically distinct from `InvalidArguments` — covers I/O failures on the terminal writer, not user input errors
- Updates `io_err_mapper` to produce `ReplError::Io` instead of `InvalidArguments`
- Updates all inline write-error closures in all command and custom command files
- Adds 2 new tests (`io_variant_display_contains_command_and_message`, `io_variant_equality`) and updates existing `io_err_mapper` tests

## Files changed

- `src/repl/error.rs` — new `Io` variant, `io_err_mapper` update, new tests
- `src/repl/commands/{cat,find,help,ls,pwd}.rs` — inline closures updated
- `src/repl/custom/{depends,history,layers,mounts,services}.rs` — `io_err` closures updated

## Test plan

- [x] All existing tests pass (678 lib, 742 total — +2 vs develop)
- [x] `io_err_mapper` tests assert `ReplError::Io` not `InvalidArguments`
- [x] New variant tests cover Display output and equality
- [x] `cargo clippy` clean, `cargo fmt` clean

Closes #65