### PR TITLE
release: v0.4.0 — Docker Compose service preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,8 @@ dependencies = [
  "anyhow",
  "clap",
  "rustyline",
+ "serde",
+ "serde_yaml",
  "tempfile",
  "thiserror",
 ]
@@ -409,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -454,6 +463,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -535,6 +557,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ clap = { version = "4", features = ["derive"] }
 rustyline = "14"
 thiserror = "2"
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # demu
 
-`demu` is a fast preview shell for Dockerfiles.
+`demu` is a fast preview shell for Dockerfiles and Docker Compose files.
 
 It lets you inspect the **filesystem, environment variables, and instruction history** a Dockerfile is trying to create — **without building or running a container**.
 
 ## Why
 
-When you are editing a `Dockerfile`, you often just want to answer questions like:
+When you are editing a `Dockerfile` or `compose.yaml`, you often just want to answer questions like:
 
 - What files would be visible?
 - What is the working directory?
@@ -14,6 +14,7 @@ When you are editing a `Dockerfile`, you often just want to answer questions lik
 - Did this `COPY` land where I think it did?
 - What did each instruction actually do?
 - Where did this file come from — a `COPY`, a `RUN`, or a previous stage?
+- What services are in this Compose file and what do they depend on?
 
 `demu` is for that fast feedback loop.
 
@@ -25,8 +26,8 @@ Download the latest release for your platform from the [Releases page](https://g
 
 ```bash
 # Linux / macOS — extract and move to PATH
-tar xzf demu-0.3.0-x86_64-unknown-linux-gnu.tar.gz
-sudo mv demu-0.3.0-x86_64-unknown-linux-gnu/demu /usr/local/bin/
+tar xzf demu-0.4.0-x86_64-unknown-linux-gnu.tar.gz
+sudo mv demu-0.4.0-x86_64-unknown-linux-gnu/demu /usr/local/bin/
 ```
 
 Available targets:
@@ -49,6 +50,8 @@ cargo install --path .
 
 ## Usage
 
+### Dockerfile mode
+
 ```bash
 demu -f Dockerfile
 ```
@@ -61,6 +64,14 @@ For multi-stage Dockerfiles, use `--stage` to inspect a specific stage:
 demu -f Dockerfile --stage builder
 demu -f Dockerfile --stage 0   # by numeric index
 ```
+
+### Compose mode
+
+```bash
+demu --compose compose.yaml --service api
+```
+
+This merges the selected service's configuration, simulates its Dockerfile, applies `working_dir`, `environment`, `env_file`, and volume mount shadows, then drops you into the same preview shell — now reflecting the service's effective state.
 
 ### Shell commands
 
@@ -85,6 +96,9 @@ demu -f Dockerfile --stage 0   # by numeric index
 | `:installed` | List all simulated package installs by manager |
 | `:explain <path>` | Show where a file came from (provenance) |
 | `:reload` | Re-read and re-simulate the Dockerfile in place |
+| `:services` | List all services in the Compose file (Compose mode) |
+| `:mounts` | Show volume mount shadows for the selected service (Compose mode) |
+| `:depends` | Show the dependency tree for the selected service (Compose mode) |
 | `which <cmd>` | Check whether a command appears to be installed |
 | `apt list --installed` | apt-style installed package listing |
 | `pip list` | pip-style installed package listing |
@@ -93,8 +107,10 @@ demu -f Dockerfile --stage 0   # by numeric index
 
 | Flag | Description |
 |------|-------------|
-| `-f <path>` | Path to the Dockerfile (required) |
+| `-f <path>` | Path to the Dockerfile (required in Dockerfile mode) |
 | `--stage <name>` | Inspect a specific stage (name or numeric index) |
+| `--compose <path>` | Path to a Compose file (enables Compose mode) |
+| `--service <name>` | Service to inspect (required with `--compose`) |
 | `--version` | Print version |
 | `--help` | Print help |
 
@@ -132,7 +148,7 @@ It prefers **fast, safe previews** over perfect fidelity. Simulated behavior is 
 
 ## Status
 
-**v0.3.0** — Multi-stage build support.
+**v0.4.0** — Docker Compose service preview.
 
 | Feature | Status |
 |---------|--------|
@@ -147,7 +163,11 @@ It prefers **fast, safe previews** over perfect fidelity. Simulated behavior is 
 | `:installed`, `which`, `:reload` | Working |
 | `apt list --installed`, `pip list` | Working |
 | Skipped-command warnings with reason | Working |
-| Compose support | Planned for v0.4 |
+| Compose YAML parsing | Working |
+| Compose service preview (`--compose`, `--service`) | Working |
+| Compose `:services`, `:mounts`, `:depends` | Working |
+| Volume mount shadows | Working |
+| Path traversal containment (build.context/dockerfile) | Working |
 
 See the [roadmap](./docs/07-roadmap.md) for the full plan.
 
@@ -173,5 +193,6 @@ docker compose -f docker-compose.dev.yml run --rm dev bash
 - [CLI and REPL](./docs/03-cli-and-repl.md)
 - [Dockerfile Semantics](./docs/04-dockerfile-semantics.md)
 - [RUN Simulation](./docs/05-run-simulation.md)
+- [Compose Plan](./docs/06-compose-plan.md)
 - [Roadmap](./docs/07-roadmap.md)
 - [Test Strategy](./docs/08-test-strategy.md)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,11 +9,56 @@ use clap::Parser;
     about = "Fast, non-destructive Docker/Compose preview shell"
 )]
 pub struct Cli {
-    /// Dockerfile to preview
+    /// Dockerfile or Compose file to preview
     #[arg(short = 'f', long = "file")]
     pub file: std::path::PathBuf,
 
-    /// Target stage (multi-stage builds)
+    /// Target stage (multi-stage Dockerfile builds)
     #[arg(long)]
     pub stage: Option<String>,
+
+    /// Switch to Compose mode (use with -f compose.yaml)
+    #[arg(long)]
+    pub compose: bool,
+
+    /// Service to inspect — required when --compose is set
+    #[arg(long)]
+    pub service: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compose_flags_are_parsed() {
+        let cli = Cli::try_parse_from([
+            "demu",
+            "--compose",
+            "-f",
+            "compose.yaml",
+            "--service",
+            "api",
+        ])
+        .expect("should parse");
+        assert!(cli.compose);
+        assert_eq!(cli.service, Some("api".to_string()));
+        assert_eq!(cli.file.to_str().unwrap(), "compose.yaml");
+    }
+
+    #[test]
+    fn compose_flag_defaults_to_false() {
+        let cli = Cli::try_parse_from(["demu", "-f", "Dockerfile"]).expect("should parse");
+        assert!(!cli.compose);
+        assert!(cli.service.is_none());
+    }
+
+    #[test]
+    fn service_without_compose_parses() {
+        // Validation is in main.rs, not clap — so this must parse without error.
+        let cli = Cli::try_parse_from(["demu", "-f", "compose.yaml", "--service", "api"])
+            .expect("should parse even without --compose");
+        assert!(!cli.compose);
+        assert_eq!(cli.service, Some("api".to_string()));
+    }
 }

--- a/src/engine/compose.rs
+++ b/src/engine/compose.rs
@@ -1,0 +1,625 @@
+//! Compose service engine — selects a service and builds its `PreviewState`.
+//!
+//! The single public entry point is [`run_compose`], which:
+//!
+//! 1. Selects the named service from a parsed [`ComposeFile`].
+//! 2. Resolves and runs the service's Dockerfile through the existing
+//!    [`engine::run`] pipeline (or starts with an empty state for image-only
+//!    services).
+//! 3. Applies Compose-level overrides: `env_file`, `environment`, `working_dir`.
+//! 4. Returns a [`ComposeEngineOutput`] with the merged state.
+//!
+//! # Override precedence (highest → lowest)
+//! 1. `environment` entries in the Compose service definition
+//! 2. `env_file` entries (last file wins for duplicate keys)
+//! 3. `ENV` instructions in the Dockerfile
+//!
+//! # Security notes
+//! - `env_file` paths are validated to stay within `compose_dir` via
+//!   canonicalization. Paths that escape the project root emit
+//!   [`Warning::EnvFileNotFound`] and are skipped.
+//! - Service names and file paths embedded in error messages are sanitized
+//!   by the caller (`main.rs`) before terminal output.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::engine;
+use crate::model::compose::{ComposeFile, EnvEntry};
+use crate::model::fs::{DirNode, FsNode};
+use crate::model::provenance::{Provenance, ProvenanceSource};
+use crate::model::state::PreviewState;
+use crate::model::warning::Warning;
+use crate::parser::dockerfile::parse_dockerfile;
+
+use super::copy::ensure_ancestors;
+
+/// Errors that prevent the Compose engine from producing a `PreviewState`.
+///
+/// These are unrecoverable failures. Recoverable conditions (missing env_file,
+/// unresolved env key) become [`Warning`]s in the returned state instead.
+#[derive(Debug, Error)]
+pub enum ComposeEngineError {
+    /// The requested service name was not found in the Compose file.
+    #[error("service '{name}' not found in compose file")]
+    ServiceNotFound { name: String },
+
+    /// The Dockerfile referenced by the service's build config does not exist.
+    #[error("Dockerfile not found: '{}'", path.display())]
+    DockerfileNotFound { path: PathBuf },
+
+    /// The Dockerfile content could not be parsed.
+    #[error("Dockerfile parse error: {message}")]
+    ParseError { message: String },
+
+    /// The engine failed while processing the Dockerfile instructions.
+    #[error("engine error: {message}")]
+    EngineError { message: String },
+
+    /// A host filesystem I/O error occurred that was not recoverable.
+    #[error("I/O error: {message}")]
+    Io { message: String },
+}
+
+/// The output of a successful compose engine run.
+#[derive(Debug)]
+pub struct ComposeEngineOutput {
+    /// The merged `PreviewState` reflecting Dockerfile + Compose overrides.
+    pub state: PreviewState,
+    /// The original `ComposeFile` (owned copy, used by `:reload`).
+    pub compose_file: ComposeFile,
+    /// The name of the service that was selected.
+    pub selected_service: String,
+}
+
+/// Run the Compose service pipeline.
+///
+/// # Arguments
+/// - `compose_file` — the parsed Compose file
+/// - `service_name` — the service to preview (must exist in `compose_file`)
+/// - `compose_dir` — the directory containing the `compose.yaml` file;
+///   used to resolve relative `build.context`, `env_file`, and `working_dir`
+///   paths
+///
+/// # Returns
+/// A [`ComposeEngineOutput`] with the merged preview state on success, or a
+/// [`ComposeEngineError`] for unrecoverable failures. Recoverable conditions
+/// (missing env_file, unresolved env keys, image-only service) are recorded as
+/// warnings in the returned state.
+pub fn run_compose(
+    compose_file: &ComposeFile,
+    service_name: &str,
+    compose_dir: &Path,
+) -> Result<ComposeEngineOutput, ComposeEngineError> {
+    // ── 1. Select the service ─────────────────────────────────────────────────
+
+    let service = compose_file.services.get(service_name).ok_or_else(|| {
+        ComposeEngineError::ServiceNotFound {
+            name: service_name.to_string(),
+        }
+    })?;
+
+    // ── 2. Build initial state (Dockerfile or empty) ──────────────────────────
+
+    let mut state = match &service.build {
+        Some(build_config) => {
+            // Resolve: compose_dir / context / dockerfile
+            let context_dir = compose_dir.join(&build_config.context);
+            let dockerfile_path = context_dir.join(&build_config.dockerfile);
+
+            if !dockerfile_path.is_file() {
+                return Err(ComposeEngineError::DockerfileNotFound {
+                    path: dockerfile_path,
+                });
+            }
+
+            let content =
+                std::fs::read_to_string(&dockerfile_path).map_err(|e| ComposeEngineError::Io {
+                    message: format!("cannot read '{}': {e}", dockerfile_path.display()),
+                })?;
+
+            let instructions =
+                parse_dockerfile(&content).map_err(|e| ComposeEngineError::ParseError {
+                    message: e.to_string(),
+                })?;
+
+            let engine_output = engine::run(instructions, &context_dir).map_err(|e| {
+                ComposeEngineError::EngineError {
+                    message: e.to_string(),
+                }
+            })?;
+
+            engine_output.state
+        }
+        None => {
+            // Image-only service: start from an empty state and record a warning.
+            let mut s = PreviewState::default();
+            let image = service
+                .image
+                .clone()
+                .unwrap_or_else(|| "<unknown>".to_string());
+            s.active_stage = Some(image.clone());
+            s.warnings.push(Warning::ImageOnlyService { image });
+            s
+        }
+    };
+
+    // ── 3. Apply env_file entries (lower precedence than environment) ─────────
+
+    // Canonicalize compose_dir once for path-containment checks.
+    // If canonicalization fails (e.g. compose_dir does not exist), fall back
+    // to using it as-is — the env_file paths will simply fail to resolve.
+    let canonical_compose_dir = compose_dir
+        .canonicalize()
+        .unwrap_or_else(|_| compose_dir.to_path_buf());
+
+    for env_file_path in &service.env_file {
+        let resolved = compose_dir.join(env_file_path);
+
+        // Security: canonicalize and check the path stays within compose_dir.
+        // Paths that escape the project root are treated as missing.
+        let safe = match resolved.canonicalize() {
+            Ok(canon) => {
+                if canon.starts_with(&canonical_compose_dir) {
+                    Some(canon)
+                } else {
+                    // Path escaped the project root — treat as missing.
+                    None
+                }
+            }
+            Err(_) => None,
+        };
+
+        match safe {
+            Some(safe_path) => match std::fs::read_to_string(&safe_path) {
+                Ok(content) => parse_env_file(&content, &mut state.env),
+                Err(_) => {
+                    state.warnings.push(Warning::EnvFileNotFound {
+                        path: env_file_path.clone(),
+                    });
+                }
+            },
+            None => {
+                state.warnings.push(Warning::EnvFileNotFound {
+                    path: env_file_path.clone(),
+                });
+            }
+        }
+    }
+
+    // ── 4. Apply environment entries (highest precedence) ─────────────────────
+
+    for entry in &service.environment {
+        match entry {
+            EnvEntry::KeyValue { key, value } => {
+                state.env.insert(key.clone(), value.clone());
+            }
+            EnvEntry::KeyOnly { key } => {
+                // At preview time the host environment is not available.
+                // Record a warning and skip rather than inserting a wrong value.
+                state
+                    .warnings
+                    .push(Warning::UnresolvedEnvKey { key: key.clone() });
+            }
+        }
+    }
+
+    // ── 5. Apply working_dir override ─────────────────────────────────────────
+
+    if let Some(ref working_dir) = service.working_dir {
+        let new_cwd = if working_dir.is_absolute() {
+            working_dir.clone()
+        } else {
+            state.cwd.join(working_dir)
+        };
+
+        // Ensure the directory and its ancestors exist in the virtual filesystem,
+        // mirroring how the engine handles WORKDIR instructions.
+        let prov = ProvenanceSource::Workdir;
+        ensure_ancestors(&mut state.fs, &new_cwd, prov.clone());
+        if !state.fs.contains(&new_cwd) {
+            state.fs.insert(
+                new_cwd.clone(),
+                FsNode::Directory(DirNode {
+                    provenance: Provenance::new(prov),
+                    permissions: None,
+                }),
+            );
+        }
+
+        state.cwd = new_cwd;
+    }
+
+    Ok(ComposeEngineOutput {
+        state,
+        compose_file: compose_file.clone(),
+        selected_service: service_name.to_string(),
+    })
+}
+
+/// Parse a `.env` file and insert entries into `env`.
+///
+/// Format rules (following Docker Compose env_file conventions):
+/// - Lines starting with `#` are comments and are skipped.
+/// - Empty or whitespace-only lines are skipped.
+/// - Lines of the form `KEY=value` are inserted; `value` may be empty.
+/// - Lines without `=` are skipped (not valid env entries in this context).
+fn parse_env_file(content: &str, env: &mut std::collections::BTreeMap<String, String>) {
+    for line in content.lines() {
+        let line = line.trim();
+        // Skip comments and blank lines.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Split on the first `=` only; everything after is the value.
+        if let Some(eq_pos) = line.find('=') {
+            let key = &line[..eq_pos];
+            let value = &line[eq_pos + 1..];
+            if !key.is_empty() {
+                env.insert(key.to_string(), value.to_string());
+            }
+        }
+        // Lines without `=` are skipped (bare KEY form is not valid in env_file).
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::model::compose::{BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition};
+    use std::collections::BTreeMap;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// Build a minimal ComposeFile with a single service.
+    fn single_service_compose(service: Service) -> ComposeFile {
+        let mut services = BTreeMap::new();
+        services.insert(service.name.clone(), service);
+        ComposeFile {
+            services,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    /// Build a bare Service with no fields set.
+    fn bare_service(name: &str) -> Service {
+        Service {
+            name: name.to_string(),
+            build: None,
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        }
+    }
+
+    /// Create a temp directory with a Dockerfile and return (TempDir, ComposeFile).
+    fn make_build_fixture(dockerfile_content: &str) -> (TempDir, ComposeFile) {
+        let dir = TempDir::new().expect("tempdir");
+        let df_path = dir.path().join("Dockerfile");
+        std::fs::write(&df_path, dockerfile_content).expect("write Dockerfile");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("svc")
+        };
+        (dir, single_service_compose(service))
+    }
+
+    // ── test 1: service not found ─────────────────────────────────────────────
+
+    #[test]
+    fn service_not_found_returns_error() {
+        let compose = ComposeFile {
+            services: BTreeMap::new(),
+            volumes: BTreeMap::new(),
+        };
+        let err = run_compose(&compose, "missing", Path::new("/tmp")).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::ServiceNotFound { .. }),
+            "expected ServiceNotFound, got: {err:?}"
+        );
+    }
+
+    // ── test 2: image-only service ────────────────────────────────────────────
+
+    #[test]
+    fn image_only_service_returns_empty_fs_with_warning() {
+        let service = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "db", Path::new("/tmp")).expect("should succeed");
+
+        // Filesystem should be effectively empty (no files from Dockerfile).
+        assert!(
+            output.state.fs.iter().count() == 0,
+            "image-only service must have empty fs; got {} nodes",
+            output.state.fs.iter().count()
+        );
+
+        // Warning::ImageOnlyService must be present.
+        let has_warning =
+            output.state.warnings.iter().any(
+                |w| matches!(w, Warning::ImageOnlyService { image } if image == "postgres:15"),
+            );
+        assert!(has_warning, "must have ImageOnlyService warning");
+
+        // active_stage should be set to the image name.
+        assert_eq!(
+            output.state.active_stage.as_deref(),
+            Some("postgres:15"),
+            "active_stage must be the image name"
+        );
+    }
+
+    // ── test 3: build service produces dockerfile filesystem ──────────────────
+
+    #[test]
+    fn build_service_produces_dockerfile_fs() {
+        let (dir, compose) = make_build_fixture("FROM scratch\nWORKDIR /app\nENV DF_VAR=hello\n");
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        // /app should exist in the virtual filesystem from WORKDIR.
+        let app_path = PathBuf::from("/app");
+        assert!(
+            output.state.fs.contains(&app_path),
+            "virtual fs must contain /app from WORKDIR"
+        );
+
+        // DF_VAR should be set from Dockerfile ENV.
+        assert_eq!(
+            output.state.env.get("DF_VAR").map(String::as_str),
+            Some("hello"),
+            "DF_VAR must be set from Dockerfile ENV"
+        );
+    }
+
+    // ── test 4: compose environment wins over dockerfile ENV ──────────────────
+
+    #[test]
+    fn env_merge_compose_wins_over_dockerfile() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nENV SHARED=from_dockerfile\n");
+
+        // Add Compose environment override.
+        compose.services.get_mut("svc").unwrap().environment = vec![EnvEntry::KeyValue {
+            key: "SHARED".to_string(),
+            value: "from_compose".to_string(),
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.env.get("SHARED").map(String::as_str),
+            Some("from_compose"),
+            "Compose environment must override Dockerfile ENV"
+        );
+    }
+
+    // ── test 5: working_dir override ─────────────────────────────────────────
+
+    #[test]
+    fn working_dir_override_sets_cwd() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nWORKDIR /app\n");
+
+        compose.services.get_mut("svc").unwrap().working_dir = Some(PathBuf::from("/override"));
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.cwd,
+            PathBuf::from("/override"),
+            "working_dir must override Dockerfile WORKDIR"
+        );
+
+        // /override should also exist in the virtual filesystem.
+        assert!(
+            output.state.fs.contains(&PathBuf::from("/override")),
+            "virtual fs must contain /override after working_dir override"
+        );
+    }
+
+    // ── test 6: env_file is loaded and merged ─────────────────────────────────
+
+    #[test]
+    fn env_file_loaded_and_merged() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("Dockerfile"), b"FROM scratch\n").expect("write df");
+        let mut env_file = std::fs::File::create(dir.path().join(".env.test")).expect("create");
+        writeln!(env_file, "ENV_FILE_VAR=from_file").expect("write env");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            env_file: vec![PathBuf::from(".env.test")],
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.env.get("ENV_FILE_VAR").map(String::as_str),
+            Some("from_file"),
+            "env var from env_file must be in state.env"
+        );
+    }
+
+    // ── test 7: missing env_file emits warning without crashing ───────────────
+
+    #[test]
+    fn missing_env_file_emits_warning() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("Dockerfile"), b"FROM scratch\n").expect("write df");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            env_file: vec![PathBuf::from(".env.nonexistent")],
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("must not error");
+
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::EnvFileNotFound { .. }));
+        assert!(has_warning, "must have EnvFileNotFound warning");
+    }
+
+    // ── test 8: KeyOnly env emits UnresolvedEnvKey warning ────────────────────
+
+    #[test]
+    fn key_only_env_emits_unresolved_warning() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\n");
+
+        compose.services.get_mut("svc").unwrap().environment = vec![EnvEntry::KeyOnly {
+            key: "HOST_VAR".to_string(),
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::UnresolvedEnvKey { key } if key == "HOST_VAR"));
+        assert!(
+            has_warning,
+            "must have UnresolvedEnvKey warning for HOST_VAR"
+        );
+
+        assert!(
+            !output.state.env.contains_key("HOST_VAR"),
+            "HOST_VAR must NOT be inserted into env"
+        );
+    }
+
+    // ── test 9: env_file before environment precedence ────────────────────────
+
+    #[test]
+    fn env_file_before_environment_precedence() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("Dockerfile"), b"FROM scratch\n").expect("write df");
+        let mut ef = std::fs::File::create(dir.path().join(".env")).expect("create");
+        writeln!(ef, "KEY=from_file").expect("write");
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            env_file: vec![PathBuf::from(".env")],
+            environment: vec![EnvEntry::KeyValue {
+                key: "KEY".to_string(),
+                value: "from_compose".to_string(),
+            }],
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        // environment entries have higher precedence than env_file entries.
+        assert_eq!(
+            output.state.env.get("KEY").map(String::as_str),
+            Some("from_compose"),
+            "environment entries must win over env_file entries"
+        );
+    }
+
+    // ── test 10: dockerfile not found returns error ───────────────────────────
+
+    #[test]
+    fn dockerfile_not_found_returns_error() {
+        let dir = TempDir::new().expect("tempdir");
+        // Do NOT create Dockerfile — it should be missing.
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let err = run_compose(&compose, "svc", dir.path()).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::DockerfileNotFound { .. }),
+            "expected DockerfileNotFound, got: {err:?}"
+        );
+    }
+
+    // ── test 11: parse_env_file parses standard format ────────────────────────
+
+    #[test]
+    fn parse_env_file_handles_comments_and_blanks() {
+        let content = "# comment\n\nKEY=value\nANOTHER=one\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(env.get("KEY").map(String::as_str), Some("value"));
+        assert_eq!(env.get("ANOTHER").map(String::as_str), Some("one"));
+        assert_eq!(env.len(), 2);
+    }
+
+    #[test]
+    fn parse_env_file_handles_empty_value() {
+        let content = "EMPTY=\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(env.get("EMPTY").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parse_env_file_skips_lines_without_equals() {
+        let content = "BARE_KEY\nKEY=value\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert!(!env.contains_key("BARE_KEY"), "bare key should be skipped");
+        assert_eq!(env.get("KEY").map(String::as_str), Some("value"));
+    }
+
+    #[test]
+    fn parse_env_file_value_may_contain_equals() {
+        let content = "URL=https://example.com/?a=1&b=2\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("URL").map(String::as_str),
+            Some("https://example.com/?a=1&b=2")
+        );
+    }
+
+    // ── test 12: output fields are populated correctly ────────────────────────
+
+    #[test]
+    fn output_fields_are_populated() {
+        let (dir, compose) = make_build_fixture("FROM scratch\n");
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(output.selected_service, "svc");
+        assert!(output.compose_file.services.contains_key("svc"));
+    }
+}

--- a/src/engine/compose.rs
+++ b/src/engine/compose.rs
@@ -15,9 +15,15 @@
 //! 3. `ENV` instructions in the Dockerfile
 //!
 //! # Security notes
-//! - `env_file` paths are validated to stay within `compose_dir` via
-//!   canonicalization. Paths that escape the project root emit
-//!   [`Warning::EnvFileNotFound`] and are skipped.
+//! - `compose_dir` is canonicalized once at the start of `run_compose`. If it
+//!   cannot be resolved the function returns `ComposeEngineError::Io`.
+//! - `build.context` and `build.dockerfile` paths are canonicalized and checked
+//!   against `canonical_compose_dir` to prevent reading arbitrary host files via
+//!   path traversal (`../../../etc/passwd`). Paths that escape the root return
+//!   [`ComposeEngineError::DockerfileNotFound`].
+//! - `env_file` paths are validated with the same canonicalize-and-contains-check.
+//!   Paths that escape the project root emit [`Warning::EnvFileNotFound`] and are
+//!   skipped.
 //! - Service names and file paths embedded in error messages are sanitized
 //!   by the caller (`main.rs`) before terminal output.
 
@@ -93,6 +99,19 @@ pub fn run_compose(
     service_name: &str,
     compose_dir: &Path,
 ) -> Result<ComposeEngineOutput, ComposeEngineError> {
+    // ── 0. Canonicalize compose_dir once — required for all path-containment checks.
+    //
+    // Security: we fail hard here rather than using a fallback. If compose_dir
+    // cannot be resolved, all downstream containment checks would be unreliable.
+    let canonical_compose_dir = compose_dir
+        .canonicalize()
+        .map_err(|e| ComposeEngineError::Io {
+            message: format!(
+                "cannot canonicalize compose directory '{}': {e}",
+                compose_dir.display()
+            ),
+        })?;
+
     // ── 1. Select the service ─────────────────────────────────────────────────
 
     let service = compose_file.services.get(service_name).ok_or_else(|| {
@@ -105,27 +124,47 @@ pub fn run_compose(
 
     let mut state = match &service.build {
         Some(build_config) => {
-            // Resolve: compose_dir / context / dockerfile
-            let context_dir = compose_dir.join(&build_config.context);
-            let dockerfile_path = context_dir.join(&build_config.dockerfile);
+            // Security: canonicalize both the context directory and the Dockerfile
+            // path, and verify each stays within canonical_compose_dir.
+            // This prevents path-traversal attacks via `context: ../../..` or
+            // `dockerfile: ../../.ssh/id_rsa` in attacker-controlled YAML.
 
-            if !dockerfile_path.is_file() {
+            let resolved_context = compose_dir.join(&build_config.context);
+            let canonical_context = resolved_context.canonicalize().map_err(|_| {
+                ComposeEngineError::DockerfileNotFound {
+                    path: resolved_context.clone(),
+                }
+            })?;
+            if !canonical_context.starts_with(&canonical_compose_dir) {
                 return Err(ComposeEngineError::DockerfileNotFound {
-                    path: dockerfile_path,
+                    path: canonical_context,
                 });
             }
 
-            let content =
-                std::fs::read_to_string(&dockerfile_path).map_err(|e| ComposeEngineError::Io {
-                    message: format!("cannot read '{}': {e}", dockerfile_path.display()),
-                })?;
+            let resolved_dockerfile = canonical_context.join(&build_config.dockerfile);
+            let canonical_dockerfile = resolved_dockerfile.canonicalize().map_err(|_| {
+                ComposeEngineError::DockerfileNotFound {
+                    path: resolved_dockerfile.clone(),
+                }
+            })?;
+            if !canonical_dockerfile.starts_with(&canonical_compose_dir) {
+                return Err(ComposeEngineError::DockerfileNotFound {
+                    path: canonical_dockerfile,
+                });
+            }
+
+            let content = std::fs::read_to_string(&canonical_dockerfile).map_err(|e| {
+                ComposeEngineError::Io {
+                    message: format!("cannot read '{}': {e}", canonical_dockerfile.display()),
+                }
+            })?;
 
             let instructions =
                 parse_dockerfile(&content).map_err(|e| ComposeEngineError::ParseError {
                     message: e.to_string(),
                 })?;
 
-            let engine_output = engine::run(instructions, &context_dir).map_err(|e| {
+            let engine_output = engine::run(instructions, &canonical_context).map_err(|e| {
                 ComposeEngineError::EngineError {
                     message: e.to_string(),
                 }
@@ -147,13 +186,6 @@ pub fn run_compose(
     };
 
     // ── 3. Apply env_file entries (lower precedence than environment) ─────────
-
-    // Canonicalize compose_dir once for path-containment checks.
-    // If canonicalization fails (e.g. compose_dir does not exist), fall back
-    // to using it as-is — the env_file paths will simply fail to resolve.
-    let canonical_compose_dir = compose_dir
-        .canonicalize()
-        .unwrap_or_else(|_| compose_dir.to_path_buf());
 
     for env_file_path in &service.env_file {
         let resolved = compose_dir.join(env_file_path);
@@ -209,11 +241,22 @@ pub fn run_compose(
     // ── 5. Apply working_dir override ─────────────────────────────────────────
 
     if let Some(ref working_dir) = service.working_dir {
-        let new_cwd = if working_dir.is_absolute() {
+        let raw_cwd = if working_dir.is_absolute() {
             working_dir.clone()
         } else {
             state.cwd.join(working_dir)
         };
+
+        // Normalize the virtual path by resolving `..` components. Only emit
+        // WorkdirEscapedRoot when a `..` component was discarded because it
+        // would go above `/` (genuine root escape). Normal `..` resolution
+        // (e.g. `/app/../etc → /etc`) does not trigger the warning.
+        let (new_cwd, was_clamped) = normalize_virtual_path(&raw_cwd);
+        if was_clamped {
+            state.warnings.push(Warning::WorkdirEscapedRoot {
+                path: working_dir.clone(),
+            });
+        }
 
         // Ensure the directory and its ancestors exist in the virtual filesystem,
         // mirroring how the engine handles WORKDIR instructions.
@@ -243,13 +286,69 @@ pub fn run_compose(
     })
 }
 
+/// Normalize a virtual (non-host) path by resolving `..` components.
+///
+/// Unlike `Path::canonicalize`, this operates on the virtual filesystem and
+/// never touches the host. If `..` would traverse above the root `/`, that
+/// component is discarded (the stack is already empty, so the pop is a no-op)
+/// and the path is effectively clamped at `/`.
+///
+/// Returns `(normalized_path, was_clamped)` where `was_clamped` is `true` only
+/// when a `..` was discarded because the stack was already empty (genuine root
+/// escape). A `..` that pops a real segment (e.g. `/app/../etc → /etc`) does
+/// **not** set `was_clamped`.
+///
+/// # Examples
+/// ```text
+/// /app/../etc    →  /etc,  was_clamped = false  (normal resolution)
+/// /app/../../    →  /,     was_clamped = true   (genuine root escape)
+/// /a/b/c         →  /a/b/c, was_clamped = false (no change)
+/// ```
+fn normalize_virtual_path(path: &Path) -> (PathBuf, bool) {
+    use std::path::Component;
+
+    let mut components: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut was_clamped = false;
+
+    for component in path.components() {
+        match component {
+            Component::RootDir => {
+                components.clear();
+                // Push nothing — we rebuild the root at join time.
+            }
+            Component::Normal(seg) => {
+                components.push(seg);
+            }
+            Component::ParentDir => {
+                if components.is_empty() {
+                    // Would go above root — discard the component and record clamping.
+                    was_clamped = true;
+                } else {
+                    components.pop();
+                }
+            }
+            // CurDir (.) and Prefix are no-ops in this context.
+            Component::CurDir | Component::Prefix(_) => {}
+        }
+    }
+
+    let mut result = PathBuf::from("/");
+    for seg in components {
+        result.push(seg);
+    }
+    (result, was_clamped)
+}
+
 /// Parse a `.env` file and insert entries into `env`.
 ///
 /// Format rules (following Docker Compose env_file conventions):
 /// - Lines starting with `#` are comments and are skipped.
 /// - Empty or whitespace-only lines are skipped.
 /// - Lines of the form `KEY=value` are inserted; `value` may be empty.
-/// - Lines without `=` are skipped (not valid env entries in this context).
+/// - Lines without `=` are skipped (bare `KEY` form is not valid in env_file).
+/// - Inline comments (`KEY=value # comment`) are stripped from values.
+/// - A single matching pair of surrounding `"` or `'` quotes is removed from
+///   values (`KEY="hello"` → `hello`, `KEY='world'` → `world`).
 fn parse_env_file(content: &str, env: &mut std::collections::BTreeMap<String, String>) {
     for line in content.lines() {
         let line = line.trim();
@@ -257,16 +356,63 @@ fn parse_env_file(content: &str, env: &mut std::collections::BTreeMap<String, St
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        // Split on the first `=` only; everything after is the value.
+        // Split on the first `=` only; everything after is the raw value.
         if let Some(eq_pos) = line.find('=') {
             let key = &line[..eq_pos];
-            let value = &line[eq_pos + 1..];
-            if !key.is_empty() {
-                env.insert(key.to_string(), value.to_string());
+            let raw_value = &line[eq_pos + 1..];
+            if key.is_empty() {
+                continue;
             }
+
+            // Strip inline comment: `value # comment` → `value`.
+            // Only strip `#` that is preceded by unquoted whitespace so that
+            // values like `URL=http://host/#anchor` are not truncated.
+            let value_no_comment = strip_inline_comment(raw_value);
+
+            // Strip a single matching pair of surrounding quotes.
+            let value = strip_surrounding_quotes(value_no_comment);
+
+            env.insert(key.to_string(), value.to_string());
         }
         // Lines without `=` are skipped (bare KEY form is not valid in env_file).
     }
+}
+
+/// Strip an inline comment from an env file value.
+///
+/// A `#` is treated as the start of a comment only when it is preceded by
+/// at least one ASCII whitespace character and is not inside a quoted section.
+/// This handles the common case while preserving URLs with `#` fragments
+/// when the value is quoted.
+fn strip_inline_comment(value: &str) -> &str {
+    // If the value is quoted, do not strip inline comments — the whole quoted
+    // string is the value. The quote stripping happens afterward.
+    let trimmed = value.trim();
+    if (trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2)
+        || (trimmed.starts_with('\'') && trimmed.ends_with('\'') && trimmed.len() >= 2)
+    {
+        return value;
+    }
+
+    // Find the first ` #` (space followed by hash) and truncate there.
+    if let Some(pos) = value.find(" #") {
+        return value[..pos].trim_end();
+    }
+    value.trim_end()
+}
+
+/// Strip a single matching pair of surrounding quotes from a value.
+///
+/// `"hello"` → `hello`, `'world'` → `world`.
+/// Unmatched or nested quotes are left as-is.
+fn strip_surrounding_quotes(value: &str) -> &str {
+    let v = value.trim();
+    if v.len() >= 2
+        && ((v.starts_with('"') && v.ends_with('"')) || (v.starts_with('\'') && v.ends_with('\'')))
+    {
+        return &v[1..v.len() - 1];
+    }
+    v
 }
 
 #[cfg(test)]
@@ -672,5 +818,294 @@ mod tests {
 
         assert_eq!(output.state.mounts.len(), 1);
         assert_eq!(output.state.mounts[0].description, "named volume: my-cache");
+    }
+
+    // ── test 14: #60 — path traversal via build.context is rejected ───────────
+
+    #[test]
+    fn context_path_traversal_returns_dockerfile_not_found() {
+        let dir = TempDir::new().expect("tempdir");
+
+        // Try to escape the compose directory via `..` in the context path.
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("../.."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let err = run_compose(&compose, "svc", dir.path()).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::DockerfileNotFound { .. }),
+            "path traversal via context must return DockerfileNotFound; got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn dockerfile_path_traversal_returns_dockerfile_not_found() {
+        let dir = TempDir::new().expect("tempdir");
+        // Create a file outside the temp dir to verify the check triggers before reading.
+        // We just need the traversal attempt to be rejected regardless of whether
+        // the target exists.
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("../../some_file"),
+            }),
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let err = run_compose(&compose, "svc", dir.path()).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::DockerfileNotFound { .. }),
+            "dockerfile path traversal must return DockerfileNotFound; got: {err:?}"
+        );
+    }
+
+    // ── test 15: #61 — working_dir with .. components is normalized ───────────
+
+    #[test]
+    fn working_dir_with_dotdot_is_normalized() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nWORKDIR /app\n");
+
+        // Relative working_dir with `..` that would escape / — should be clamped.
+        compose.services.get_mut("svc").unwrap().working_dir = Some(PathBuf::from("../../../etc"));
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        // The CWD must not contain `..` components.
+        let cwd_str = output.state.cwd.to_string_lossy();
+        assert!(
+            !cwd_str.contains(".."),
+            "normalized CWD must not contain '..'; got: {cwd_str}"
+        );
+
+        // A WorkdirEscapedRoot warning must be emitted.
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::WorkdirEscapedRoot { .. }));
+        assert!(has_warning, "must have WorkdirEscapedRoot warning");
+    }
+
+    #[test]
+    fn working_dir_absolute_with_dotdot_is_normalized() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\n");
+
+        // /app/../../etc: first .. pops app (stack non-empty → no clamp),
+        // second .. hits empty stack → genuine root escape → clamped → warning emitted.
+        compose.services.get_mut("svc").unwrap().working_dir =
+            Some(PathBuf::from("/app/../../etc"));
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.cwd,
+            PathBuf::from("/etc"),
+            "absolute path with .. should normalize correctly"
+        );
+
+        // The second `..` escapes the virtual root, so WorkdirEscapedRoot must be emitted.
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::WorkdirEscapedRoot { .. }));
+        assert!(
+            has_warning,
+            "/app/../../etc has a genuine root escape — must emit WorkdirEscapedRoot"
+        );
+    }
+
+    #[test]
+    fn working_dir_dotdot_within_bounds_no_warning() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\n");
+
+        // /app/../etc: the .. pops app (stack non-empty → no clamping). No root escape.
+        compose.services.get_mut("svc").unwrap().working_dir = Some(PathBuf::from("/app/../etc"));
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.cwd,
+            PathBuf::from("/etc"),
+            "path with single in-bounds .. should resolve to /etc"
+        );
+
+        let has_warning = output
+            .state
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::WorkdirEscapedRoot { .. }));
+        assert!(
+            !has_warning,
+            "/app/../etc does not escape root — must NOT emit WorkdirEscapedRoot"
+        );
+    }
+
+    // ── test 16: normalize_virtual_path unit tests ────────────────────────────
+
+    #[test]
+    fn normalize_virtual_path_resolves_dotdot() {
+        // Normal `..` resolution — no clamping.
+        let (path, clamped) = normalize_virtual_path(&PathBuf::from("/app/../etc"));
+        assert_eq!(path, PathBuf::from("/etc"));
+        assert!(!clamped, "normal .. resolution must not set was_clamped");
+    }
+
+    #[test]
+    fn normalize_virtual_path_clamps_above_root() {
+        // `..` on an empty stack — genuine root escape → was_clamped = true.
+        let (path, clamped) = normalize_virtual_path(&PathBuf::from("/../../etc"));
+        assert_eq!(path, PathBuf::from("/etc"));
+        assert!(clamped, "/../../etc must set was_clamped");
+    }
+
+    #[test]
+    fn normalize_virtual_path_no_change() {
+        let (path, clamped) = normalize_virtual_path(&PathBuf::from("/app/data"));
+        assert_eq!(path, PathBuf::from("/app/data"));
+        assert!(!clamped, "path without .. must not set was_clamped");
+    }
+
+    #[test]
+    fn normalize_virtual_path_root() {
+        let (path, clamped) = normalize_virtual_path(&PathBuf::from("/"));
+        assert_eq!(path, PathBuf::from("/"));
+        assert!(!clamped, "root path must not set was_clamped");
+    }
+
+    #[test]
+    fn normalize_virtual_path_dotdot_within_bounds_not_clamped() {
+        // /a/b/../c resolves to /a/c — the .. pops b (non-empty stack), so no clamping.
+        let (path, clamped) = normalize_virtual_path(&PathBuf::from("/a/b/../c"));
+        assert_eq!(path, PathBuf::from("/a/c"));
+        assert!(!clamped, "/a/b/../c must not set was_clamped");
+    }
+
+    // ── test 17: #62 — parse_env_file strips inline comments and quotes ───────
+
+    #[test]
+    fn parse_env_file_strips_inline_comment() {
+        let content = "KEY=value # this is a comment\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("KEY").map(String::as_str),
+            Some("value"),
+            "inline comment must be stripped; got: {:?}",
+            env.get("KEY")
+        );
+    }
+
+    #[test]
+    fn parse_env_file_strips_double_quotes() {
+        let content = "KEY=\"hello world\"\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("KEY").map(String::as_str),
+            Some("hello world"),
+            "double quotes must be stripped; got: {:?}",
+            env.get("KEY")
+        );
+    }
+
+    #[test]
+    fn parse_env_file_strips_single_quotes() {
+        let content = "KEY='single quoted'\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("KEY").map(String::as_str),
+            Some("single quoted"),
+            "single quotes must be stripped; got: {:?}",
+            env.get("KEY")
+        );
+    }
+
+    #[test]
+    fn parse_env_file_url_with_hash_in_quotes_preserved() {
+        // A quoted URL with a `#` fragment should NOT have the fragment stripped.
+        let content = "URL=\"http://host/#anchor\"\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("URL").map(String::as_str),
+            Some("http://host/#anchor"),
+            "hash in quoted value must be preserved; got: {:?}",
+            env.get("URL")
+        );
+    }
+
+    #[test]
+    fn parse_env_file_unquoted_url_with_equals_preserved() {
+        // Value with embedded `=` must not be truncated.
+        let content = "URL=https://example.com/?a=1\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("URL").map(String::as_str),
+            Some("https://example.com/?a=1")
+        );
+    }
+
+    #[test]
+    fn parse_env_file_hash_without_space_is_preserved() {
+        // `#` without a preceding space is NOT a comment — it is part of the value.
+        // Docker Compose env_file spec: only ` #` (space then hash) starts a comment.
+        let content = "KEY=value#nospace\n";
+        let mut env = BTreeMap::new();
+        parse_env_file(content, &mut env);
+        assert_eq!(
+            env.get("KEY").map(String::as_str),
+            Some("value#nospace"),
+            "hash without preceding space must be preserved; got: {:?}",
+            env.get("KEY")
+        );
+    }
+
+    // ── test 18: dockerfile traversal starts_with guard (not just canonicalize ENOENT) ──
+
+    #[test]
+    fn dockerfile_path_traversal_rejected_by_containment_check() {
+        use std::fs;
+
+        // Create two sibling temp directories: compose_dir and outside_dir.
+        let compose_dir = TempDir::new().expect("compose tempdir");
+        let outside_dir = TempDir::new().expect("outside tempdir");
+
+        // Write a real file in outside_dir so canonicalize() succeeds on it.
+        let outside_dockerfile = outside_dir.path().join("Dockerfile");
+        fs::write(&outside_dockerfile, "FROM scratch\n").expect("write outside Dockerfile");
+
+        // Build a relative path from compose_dir that traverses to outside_dir.
+        // sibling_rel = "../<outside_dir_name>/Dockerfile"
+        let outside_name = outside_dir
+            .path()
+            .file_name()
+            .expect("outside dir name")
+            .to_str()
+            .expect("utf-8 name");
+        let dockerfile_rel = PathBuf::from(format!("../{outside_name}/Dockerfile"));
+
+        let service = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: dockerfile_rel,
+            }),
+            ..bare_service("svc")
+        };
+        let compose = single_service_compose(service);
+
+        let err = run_compose(&compose, "svc", compose_dir.path()).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeEngineError::DockerfileNotFound { .. }),
+            "dockerfile path escaping compose_dir must be rejected by starts_with guard; got: {err:?}"
+        );
     }
 }

--- a/src/engine/compose.rs
+++ b/src/engine/compose.rs
@@ -34,6 +34,7 @@ use crate::model::warning::Warning;
 use crate::parser::dockerfile::parse_dockerfile;
 
 use super::copy::ensure_ancestors;
+use super::mount::apply_mount_shadows;
 
 /// Errors that prevent the Compose engine from producing a `PreviewState`.
 ///
@@ -231,6 +232,10 @@ pub fn run_compose(
         state.cwd = new_cwd;
     }
 
+    // ── 6. Apply volume mount shadows ─────────────────────────────────────────
+
+    apply_mount_shadows(&mut state, &service.volumes);
+
     Ok(ComposeEngineOutput {
         state,
         compose_file: compose_file.clone(),
@@ -268,7 +273,9 @@ fn parse_env_file(content: &str, env: &mut std::collections::BTreeMap<String, St
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::model::compose::{BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition};
+    use crate::model::compose::{
+        BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition, VolumeSpec,
+    };
     use std::collections::BTreeMap;
     use std::io::Write;
     use tempfile::TempDir;
@@ -621,5 +628,49 @@ mod tests {
 
         assert_eq!(output.selected_service, "svc");
         assert!(output.compose_file.services.contains_key("svc"));
+    }
+
+    // ── test 13: volume mounts are applied as shadows ─────────────────────────
+
+    #[test]
+    fn bind_volume_recorded_in_state_mounts() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\nWORKDIR /app\n");
+
+        compose.services.get_mut("svc").unwrap().volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./data"),
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(
+            output.state.mounts.len(),
+            1,
+            "one bind mount must be recorded"
+        );
+        assert!(
+            output.state.mounts[0]
+                .description
+                .contains("bind mount from"),
+            "description must mention bind mount; got: {}",
+            output.state.mounts[0].description
+        );
+    }
+
+    #[test]
+    fn named_volume_recorded_in_state_mounts() {
+        let (dir, mut compose) = make_build_fixture("FROM scratch\n");
+
+        compose.services.get_mut("svc").unwrap().volumes = vec![VolumeSpec::Named {
+            volume_name: "my-cache".to_string(),
+            container_path: PathBuf::from("/cache"),
+            read_only: false,
+        }];
+
+        let output = run_compose(&compose, "svc", dir.path()).expect("should succeed");
+
+        assert_eq!(output.state.mounts.len(), 1);
+        assert_eq!(output.state.mounts[0].description, "named volume: my-cache");
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,7 @@
 pub mod compose;
 mod copy;
 pub mod error;
+pub mod mount;
 mod run_sim;
 mod runner;
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,12 +3,17 @@
 //! The single public entry point is [`run`], which walks a `Vec<Instruction>`
 //! and returns an [`EngineOutput`] containing the final stage's [`PreviewState`]
 //! and a [`StageRegistry`] for all stages.
+//!
+//! The compose engine entry point is [`compose::run_compose`], which builds a
+//! merged `PreviewState` from a parsed `ComposeFile` and a selected service.
 
+pub mod compose;
 mod copy;
 pub mod error;
 mod run_sim;
 mod runner;
 
+pub use compose::{run_compose, ComposeEngineError, ComposeEngineOutput};
 pub use error::EngineError;
 pub use runner::{run, EngineOutput};
 // Re-export StageRegistry from the model so callers can use engine::StageRegistry

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -1,0 +1,327 @@
+// Mount shadow engine — applies Compose volume mounts to the preview state.
+//
+// `apply_mount_shadows` converts each `VolumeSpec` from a Compose service
+// definition into a `MountInfo` record and:
+//
+// 1. Attaches the mount info to any existing FS node at the container path
+//    (so `:explain` can report that a path is shadowed by a volume mount).
+// 2. Appends the mount info to `state.mounts` (so `:mounts` can list all
+//    active mount shadows).
+//
+// The host filesystem is never accessed — `host_path` values in `Bind`
+// specs are used only as display strings in the mount description.
+
+use crate::model::compose::VolumeSpec;
+use crate::model::provenance::MountInfo;
+use crate::model::state::PreviewState;
+
+/// Apply volume mount shadows from `volumes` to `state`.
+///
+/// For each `VolumeSpec`:
+/// - A `MountInfo` is constructed with the container path, read-only flag,
+///   and a human-readable description.
+/// - If an FS node exists at the container path it is annotated with
+///   `shadowed_by_mount`.
+/// - The mount info is always recorded in `state.mounts` regardless of
+///   whether a matching FS node exists.
+pub fn apply_mount_shadows(state: &mut PreviewState, volumes: &[VolumeSpec]) {
+    for vol in volumes {
+        let info = build_mount_info(vol);
+
+        // Shadow any FS node that already exists at the container path.
+        // Using `info.container_path` directly avoids a redundant extraction
+        // and keeps the path used for FS lookup in sync with the stored mount.
+        if let Some(node) = state.fs.get_mut(&info.container_path) {
+            node.provenance_mut().shadowed_by_mount = Some(info.clone());
+        }
+
+        // Always record in the mounts list for `:mounts` display.
+        state.mounts.push(info);
+    }
+}
+
+/// Build a `MountInfo` from a `VolumeSpec`.
+///
+/// The `description` is computed once here so it can be stored in both
+/// `Provenance::shadowed_by_mount` and `state.mounts` without needing
+/// to reconstruct it at display time.
+fn build_mount_info(spec: &VolumeSpec) -> MountInfo {
+    match spec {
+        VolumeSpec::Bind {
+            host_path,
+            container_path,
+            read_only,
+        } => MountInfo {
+            container_path: container_path.clone(),
+            read_only: *read_only,
+            description: format!("bind mount from {}", host_path.display()),
+        },
+        VolumeSpec::Named {
+            volume_name,
+            container_path,
+            read_only,
+        } => MountInfo {
+            container_path: container_path.clone(),
+            read_only: *read_only,
+            description: format!("named volume: {volume_name}"),
+        },
+        VolumeSpec::Anonymous { container_path } => MountInfo {
+            container_path: container_path.clone(),
+            read_only: false,
+            description: "anonymous volume".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::fs::{DirNode, FileNode, FsNode};
+    use crate::model::provenance::{Provenance, ProvenanceSource};
+    use crate::model::state::PreviewState;
+    use std::path::PathBuf;
+
+    fn workdir_provenance() -> Provenance {
+        Provenance::new(ProvenanceSource::Workdir)
+    }
+
+    fn state_with_dir(path: &str) -> PreviewState {
+        let mut state = PreviewState::default();
+        let node = FsNode::Directory(DirNode {
+            provenance: workdir_provenance(),
+            permissions: None,
+        });
+        state.fs.insert(PathBuf::from(path), node);
+        state
+    }
+
+    fn state_with_file(path: &str) -> PreviewState {
+        let mut state = PreviewState::default();
+        let node = FsNode::File(FileNode {
+            content: vec![],
+            provenance: workdir_provenance(),
+            permissions: None,
+        });
+        state.fs.insert(PathBuf::from(path), node);
+        state
+    }
+
+    // --- apply_mount_shadows: records mounts in state.mounts ---
+
+    #[test]
+    fn bind_spec_is_recorded_in_state_mounts() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./data"),
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 1);
+        assert_eq!(state.mounts[0].container_path, PathBuf::from("/data"));
+        // PathBuf strips leading "./" — "bind mount from data" is expected.
+        assert!(
+            state.mounts[0].description.starts_with("bind mount from"),
+            "got: {}",
+            state.mounts[0].description
+        );
+        assert!(!state.mounts[0].read_only);
+    }
+
+    #[test]
+    fn named_spec_is_recorded_in_state_mounts() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Named {
+            volume_name: "npm-cache".to_string(),
+            container_path: PathBuf::from("/root/.npm"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 1);
+        assert_eq!(state.mounts[0].description, "named volume: npm-cache");
+        assert_eq!(state.mounts[0].container_path, PathBuf::from("/root/.npm"));
+    }
+
+    #[test]
+    fn anonymous_spec_is_recorded_in_state_mounts() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Anonymous {
+            container_path: PathBuf::from("/tmp/scratch"),
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 1);
+        assert_eq!(state.mounts[0].description, "anonymous volume");
+        assert!(!state.mounts[0].read_only);
+    }
+
+    #[test]
+    fn read_only_bind_sets_read_only_true_in_mount_info() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./config"),
+            container_path: PathBuf::from("/config"),
+            read_only: true,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert!(state.mounts[0].read_only);
+    }
+
+    #[test]
+    fn read_only_named_sets_read_only_true_in_mount_info() {
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Named {
+            volume_name: "shared-data".to_string(),
+            container_path: PathBuf::from("/shared"),
+            read_only: true,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert!(state.mounts[0].read_only);
+    }
+
+    // --- apply_mount_shadows: shadows existing FS nodes ---
+
+    #[test]
+    fn existing_dir_node_gets_shadowed_by_bind_mount() {
+        let mut state = state_with_dir("/data");
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./data"),
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+
+        let node = state
+            .fs
+            .get(&PathBuf::from("/data"))
+            .expect("/data must exist");
+        let shadow = node
+            .provenance()
+            .shadowed_by_mount
+            .as_ref()
+            .expect("must be shadowed");
+        assert_eq!(shadow.container_path, PathBuf::from("/data"));
+        assert!(shadow.description.contains("bind mount from"));
+    }
+
+    #[test]
+    fn existing_file_node_gets_shadowed_by_named_mount() {
+        let mut state = state_with_file("/app/config.json");
+        let volumes = vec![VolumeSpec::Named {
+            volume_name: "config-vol".to_string(),
+            container_path: PathBuf::from("/app/config.json"),
+            read_only: true,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+
+        let node = state
+            .fs
+            .get(&PathBuf::from("/app/config.json"))
+            .expect("must exist");
+        let shadow = node
+            .provenance()
+            .shadowed_by_mount
+            .as_ref()
+            .expect("must be shadowed");
+        assert_eq!(shadow.description, "named volume: config-vol");
+        assert!(shadow.read_only);
+    }
+
+    // --- apply_mount_shadows: nonexistent path still records mount ---
+
+    #[test]
+    fn nonexistent_container_path_still_records_in_state_mounts() {
+        // The path doesn't exist in the FS — no node to shadow — but
+        // the mount must still appear in state.mounts for `:mounts`.
+        let mut state = PreviewState::default();
+        let volumes = vec![VolumeSpec::Bind {
+            host_path: PathBuf::from("./uploads"),
+            container_path: PathBuf::from("/uploads"),
+            read_only: false,
+        }];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(
+            state.mounts.len(),
+            1,
+            "mount must be recorded even without an FS node"
+        );
+        // No node at /uploads — FS remains empty.
+        assert!(state.fs.get(&PathBuf::from("/uploads")).is_none());
+    }
+
+    // --- apply_mount_shadows: multiple volumes ---
+
+    #[test]
+    fn multiple_volumes_all_recorded() {
+        let mut state = PreviewState::default();
+        let volumes = vec![
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./data"),
+                container_path: PathBuf::from("/data"),
+                read_only: false,
+            },
+            VolumeSpec::Named {
+                volume_name: "cache".to_string(),
+                container_path: PathBuf::from("/cache"),
+                read_only: false,
+            },
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/tmp"),
+            },
+        ];
+        apply_mount_shadows(&mut state, &volumes);
+        assert_eq!(state.mounts.len(), 3);
+    }
+
+    #[test]
+    fn empty_volumes_list_leaves_state_unchanged() {
+        let mut state = PreviewState::default();
+        apply_mount_shadows(&mut state, &[]);
+        assert!(state.mounts.is_empty());
+    }
+
+    // --- duplicate container path: last-writer-wins for shadowed_by_mount ---
+    //
+    // When two VolumeSpec entries share the same container path, state.mounts
+    // records both (so `:mounts` shows two entries) but the FS node's
+    // shadowed_by_mount carries only the last one (last-writer-wins).
+    // This test specifies that behavior explicitly so any future change is
+    // visible.
+
+    #[test]
+    fn duplicate_container_path_last_writer_wins_for_fs_shadow() {
+        let mut state = state_with_dir("/data");
+        let volumes = vec![
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./first"),
+                container_path: PathBuf::from("/data"),
+                read_only: false,
+            },
+            VolumeSpec::Named {
+                volume_name: "second".to_string(),
+                container_path: PathBuf::from("/data"),
+                read_only: true,
+            },
+        ];
+        apply_mount_shadows(&mut state, &volumes);
+
+        // Both entries are recorded in state.mounts.
+        assert_eq!(state.mounts.len(), 2, "both mounts must be in state.mounts");
+
+        // The FS node at /data retains only the last mount shadow (last-writer-wins).
+        let node = state
+            .fs
+            .get(&PathBuf::from("/data"))
+            .expect("/data must exist");
+        let shadow = node
+            .provenance()
+            .shadowed_by_mount
+            .as_ref()
+            .expect("must be shadowed");
+        assert_eq!(
+            shadow.description, "named volume: second",
+            "last VolumeSpec must win for shadowed_by_mount; got: {}",
+            shadow.description
+        );
+    }
+}

--- a/src/explain/mod.rs
+++ b/src/explain/mod.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::model::{
-    provenance::{MountInfo, MountKind, ProvenanceSource},
+    provenance::{MountInfo, ProvenanceSource},
     state::PreviewState,
 };
 use crate::output::sanitize::sanitize_for_terminal;
@@ -122,17 +122,10 @@ fn format_source(source: &ProvenanceSource) -> String {
 
 /// Format a `MountInfo` as a human-readable string.
 ///
-/// The output describes the kind of mount and the source path or name.
-/// The `source` field is user-supplied and sanitized before interpolation.
+/// Returns the pre-formatted `description` field, sanitizing it against
+/// ANSI escape injection before emitting it to the terminal.
 fn format_mount(mount: &MountInfo) -> String {
-    let safe_source = sanitize_for_terminal(&mount.source);
-    match mount.mount_type {
-        MountKind::Bind => format!("bind mount from {safe_source}"),
-        MountKind::Volume => format!("volume mount: {safe_source}"),
-        MountKind::Tmpfs => "tmpfs mount".to_string(),
-        MountKind::Cache => format!("cache mount from {safe_source}"),
-        MountKind::Secret => format!("secret mount: {safe_source}"),
-    }
+    sanitize_for_terminal(&mount.description)
 }
 
 #[cfg(test)]
@@ -141,7 +134,7 @@ mod tests {
     use super::*;
     use crate::model::{
         fs::{FileNode, FsNode},
-        provenance::{MountInfo, MountKind, Provenance, ProvenanceSource},
+        provenance::{MountInfo, Provenance, ProvenanceSource},
         state::PreviewState,
     };
     use std::path::PathBuf;
@@ -268,8 +261,9 @@ mod tests {
             host_path: PathBuf::from("src/main.rs"),
         });
         prov.shadowed_by_mount = Some(MountInfo {
-            source: "/host/path".to_string(),
-            mount_type: MountKind::Bind,
+            container_path: PathBuf::from("/app/main.rs"),
+            read_only: false,
+            description: "bind mount from /host/path".to_string(),
         });
         let state = state_with_node("/app/main.rs", prov);
         let output = explain_path(&state, Path::new("/app/main.rs")).expect("should succeed");
@@ -352,42 +346,36 @@ mod tests {
         );
     }
 
-    // --- mount kind format tests ---
+    // --- mount description format tests ---
 
     #[test]
-    fn format_mount_volume_shows_volume_name() {
+    fn format_mount_returns_description() {
         let mount = MountInfo {
-            source: "myvolume".to_string(),
-            mount_type: MountKind::Volume,
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "named volume: myvolume".to_string(),
         };
-        assert_eq!(format_mount(&mount), "volume mount: myvolume");
+        assert_eq!(format_mount(&mount), "named volume: myvolume");
     }
 
     #[test]
-    fn format_mount_tmpfs_shows_tmpfs_label() {
+    fn format_mount_anonymous_volume() {
         let mount = MountInfo {
-            source: "ignored".to_string(),
-            mount_type: MountKind::Tmpfs,
+            container_path: PathBuf::from("/tmp"),
+            read_only: false,
+            description: "anonymous volume".to_string(),
         };
-        assert_eq!(format_mount(&mount), "tmpfs mount");
+        assert_eq!(format_mount(&mount), "anonymous volume");
     }
 
     #[test]
-    fn format_mount_cache_shows_source() {
+    fn format_mount_bind_description() {
         let mount = MountInfo {
-            source: "/cache/go".to_string(),
-            mount_type: MountKind::Cache,
+            container_path: PathBuf::from("/app"),
+            read_only: true,
+            description: "bind mount from ./src".to_string(),
         };
-        assert_eq!(format_mount(&mount), "cache mount from /cache/go");
-    }
-
-    #[test]
-    fn format_mount_secret_shows_name() {
-        let mount = MountInfo {
-            source: "mysecret".to_string(),
-            mount_type: MountKind::Secret,
-        };
-        assert_eq!(format_mount(&mount), "secret mount: mysecret");
+        assert_eq!(format_mount(&mount), "bind mount from ./src");
     }
 
     // --- sanitization of user-controlled fields ---
@@ -423,10 +411,11 @@ mod tests {
     }
 
     #[test]
-    fn format_mount_strips_ansi_escape_in_source() {
+    fn format_mount_strips_ansi_escape_in_description() {
         let mount = MountInfo {
-            source: "/host/\x1b[2Jpath".to_string(),
-            mount_type: MountKind::Bind,
+            container_path: PathBuf::from("/app"),
+            read_only: false,
+            description: "bind mount from /host/\x1b[2Jpath".to_string(),
         };
         let result = format_mount(&mount);
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 // `demu` binary entrypoint.
 //
 // Wires together the full preview pipeline:
+//
+// Dockerfile mode (default):
 //   1. Parse CLI arguments with clap (`Cli`).
 //   2. Validate the Dockerfile path (exists and is a regular file).
 //   3. Canonicalize the path to derive an absolute build-context directory.
@@ -10,6 +12,14 @@
 //   7. Print any engine warnings to stderr.
 //   8. Hand the resulting `PreviewState` to the interactive REPL.
 //
+// Compose mode (`--compose`):
+//   1. Parse CLI arguments with clap (`Cli`).
+//   2. Validate `--service` is present.
+//   3. Validate and canonicalize the Compose file path.
+//   4. Read and parse the Compose file.
+//   5. Validate the service name exists.
+//   6. Enter the REPL with a default `PreviewState` (engine merge comes in #50).
+//
 // `run_cli` returns `anyhow::Result<()>` so that every error path funnels
 // through the single `main` handler, which formats the message as
 // `"demu: <err>"` before exiting with code 1.
@@ -17,9 +27,89 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use demu::{
-    engine, output::sanitize::sanitize_for_terminal, parser::dockerfile::parse_dockerfile,
-    repl::config::ReplConfig, repl::run_repl, Cli,
+    engine,
+    model::state::PreviewState,
+    output::sanitize::sanitize_for_terminal,
+    parser::{compose::parse_compose, dockerfile::parse_dockerfile},
+    repl::config::{ComposeContext, ReplConfig},
+    repl::run_repl,
+    Cli,
 };
+
+/// Compose-mode pipeline.
+///
+/// Validates flags, parses the Compose file, selects the service, and enters
+/// the REPL with a default `PreviewState`. Engine integration (#50) will replace
+/// the default state with a fully merged Compose view.
+fn run_compose_pipeline(cli: &Cli) -> Result<()> {
+    // ── 1. Require --service ─────────────────────────────────────────────────
+
+    let service_name = cli.service.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("--service <name> is required in compose mode (--compose)")
+    })?;
+
+    // ── 2. Validate the Compose file path ────────────────────────────────────
+
+    if !cli.file.exists() {
+        anyhow::bail!("Compose file not found: '{}'", cli.file.display());
+    }
+    if !cli.file.is_file() {
+        anyhow::bail!(
+            "'{}' is not a regular file — pass the path to a compose.yaml",
+            cli.file.display()
+        );
+    }
+
+    let canonical = cli
+        .file
+        .canonicalize()
+        .with_context(|| format!("cannot resolve path '{}'", cli.file.display()))?;
+
+    // ── 3. Read and parse the Compose file ───────────────────────────────────
+
+    let content = std::fs::read_to_string(&canonical)
+        .with_context(|| format!("cannot read '{}'", canonical.display()))?;
+
+    let compose_file = parse_compose(&content)
+        .map_err(|e| anyhow::anyhow!("failed to parse '{}': {}", canonical.display(), e))?;
+
+    // ── 4. Validate the service name ─────────────────────────────────────────
+
+    if !compose_file.services.contains_key(service_name) {
+        let safe_name = sanitize_for_terminal(service_name);
+        let available = compose_file
+            .services
+            .keys()
+            .map(|k| sanitize_for_terminal(k))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "service '{}' not found; available services: {}",
+            safe_name,
+            available
+        );
+    }
+
+    // ── 5. Build the session config ──────────────────────────────────────────
+
+    // Engine integration (#50) will replace the stub state with a full merged
+    // Compose preview. For now, enter the REPL with an empty default state so
+    // that the flags and routing are functional end-to-end.
+    let mut state = PreviewState::default();
+
+    let compose_context = ComposeContext {
+        compose_file,
+        selected_service: service_name.to_string(),
+    };
+
+    let repl_config = ReplConfig::new(canonical).with_compose_context(Some(compose_context));
+
+    // ── 6. Enter the REPL ────────────────────────────────────────────────────
+
+    run_repl(&mut state, &repl_config)?;
+
+    Ok(())
+}
 
 /// Full CLI pipeline. Returns `Err` for any unrecoverable failure.
 ///
@@ -27,6 +117,12 @@ use demu::{
 /// formatting in `main` trivially straightforward.
 fn run_cli() -> Result<()> {
     let cli = Cli::parse();
+
+    // ── Route to Compose pipeline if --compose is set ────────────────────────
+
+    if cli.compose {
+        return run_compose_pipeline(&cli);
+    }
 
     // ── 1. Validate the path ─────────────────────────────────────────────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,12 @@ fn run_cli() -> Result<()> {
         return run_compose_pipeline(&cli);
     }
 
+    // Warn if --service was passed without --compose. The flag is silently
+    // ignored in Dockerfile mode, which would be very confusing to the user.
+    if cli.service.is_some() {
+        eprintln!("warning: --service is only valid with --compose; ignoring");
+    }
+
     // ── 1. Validate the path ─────────────────────────────────────────────────
 
     // The path must exist — surface a clear error rather than a confusing I/O

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use demu::{
     engine,
-    model::state::PreviewState,
     output::sanitize::sanitize_for_terminal,
     parser::{compose::parse_compose, dockerfile::parse_dockerfile},
     repl::config::{ComposeContext, ReplConfig},
@@ -90,21 +89,42 @@ fn run_compose_pipeline(cli: &Cli) -> Result<()> {
         );
     }
 
-    // ── 5. Build the session config ──────────────────────────────────────────
+    // ── 5. Derive the compose directory ──────────────────────────────────────
 
-    // Engine integration (#50) will replace the stub state with a full merged
-    // Compose preview. For now, enter the REPL with an empty default state so
-    // that the flags and routing are functional end-to-end.
-    let mut state = PreviewState::default();
+    let compose_dir = canonical
+        .parent()
+        .with_context(|| {
+            format!(
+                "cannot determine parent directory of '{}'",
+                canonical.display()
+            )
+        })?
+        .to_path_buf();
+
+    // ── 6. Run the compose engine ─────────────────────────────────────────────
+
+    let compose_output = engine::run_compose(&compose_file, service_name, &compose_dir)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    // ── 7. Print warnings to stderr ───────────────────────────────────────────
+
+    let mut state = compose_output.state;
+    for warning in &state.warnings {
+        let safe = sanitize_for_terminal(&warning.to_string());
+        eprintln!("warning: {safe}");
+    }
+
+    // ── 8. Build the session config ───────────────────────────────────────────
 
     let compose_context = ComposeContext {
         compose_file,
         selected_service: service_name.to_string(),
     };
 
-    let repl_config = ReplConfig::new(canonical).with_compose_context(Some(compose_context));
+    let repl_config = ReplConfig::with_context(canonical, compose_dir)
+        .with_compose_context(Some(compose_context));
 
-    // ── 6. Enter the REPL ────────────────────────────────────────────────────
+    // ── 9. Enter the REPL ────────────────────────────────────────────────────
 
     run_repl(&mut state, &repl_config)?;
 

--- a/src/model/compose.rs
+++ b/src/model/compose.rs
@@ -1,0 +1,142 @@
+//! Domain model types for Docker Compose files.
+//!
+//! These types represent the clean, validated view of a `docker-compose.yml`
+//! after parsing.  They intentionally do **not** derive `Deserialize` — that
+//! concern lives in the parser module where intermediate raw types are used
+//! to handle Compose's many dual-form fields (string *or* map, list *or* dict,
+//! etc.).
+//!
+//! # Module layout
+//!
+//! | Type | Purpose |
+//! |------|---------|
+//! | `ComposeFile` | Top-level container: services + named-volume declarations |
+//! | `Service` | One `docker-compose.yml` service definition |
+//! | `BuildConfig` | Build context and Dockerfile path |
+//! | `EnvEntry` | A single environment variable (key=value or bare key) |
+//! | `VolumeSpec` | A per-service volume mount (bind, named, or anonymous) |
+//! | `VolumeDefinition` | A top-level named volume declaration |
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// The top-level structure of a parsed `docker-compose.yml`.
+///
+/// `services` is always present (parsing fails if the key is missing).
+/// `volumes` may be empty when no top-level named volumes are declared.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComposeFile {
+    /// All service definitions keyed by service name.
+    pub services: BTreeMap<String, Service>,
+    /// Top-level named volume declarations keyed by volume name.
+    pub volumes: BTreeMap<String, VolumeDefinition>,
+}
+
+/// A single service definition inside a Compose file.
+///
+/// Fields mirror the most commonly used Compose keys.  Unknown keys in the
+/// source YAML are silently ignored — this matches Docker's own tolerant
+/// parsing behaviour and keeps the preview useful even for complex files.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Service {
+    /// The service name (taken from the YAML map key, not a field inside the
+    /// service map).
+    pub name: String,
+    /// Build configuration when the service is built from a local context.
+    pub build: Option<BuildConfig>,
+    /// Pre-built image reference (e.g. `"postgres:15"`).
+    pub image: Option<String>,
+    /// Environment variables injected into the container.
+    pub environment: Vec<EnvEntry>,
+    /// Paths to env-file(s) whose contents are injected as environment
+    /// variables.
+    ///
+    /// # Security note
+    /// Stored verbatim from the YAML — may contain `..` components. Callers
+    /// must validate these paths against the project root before reading them
+    /// from the host filesystem.
+    pub env_file: Vec<PathBuf>,
+    /// Volume mounts for this service.
+    pub volumes: Vec<VolumeSpec>,
+    /// Working directory override inside the container.
+    pub working_dir: Option<PathBuf>,
+    /// Names of services that must start before this one.
+    pub depends_on: Vec<String>,
+    /// Port mappings (kept as raw strings — format varies widely and we only
+    /// need them for informational display, not actual binding).
+    pub ports: Vec<String>,
+}
+
+/// Build configuration for a service that is built from local source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BuildConfig {
+    /// The build context directory (e.g. `"."` or `"./services/api"`).
+    ///
+    /// # Security note
+    /// Stored verbatim from the YAML — may contain `..` components. Callers
+    /// that use this path for host filesystem access **must** canonicalize it
+    /// and verify it does not escape the declared project root before opening
+    /// any file.
+    pub context: PathBuf,
+    /// Path to the Dockerfile relative to `context`.  Defaults to
+    /// `"Dockerfile"` when only a short-form string is given.
+    ///
+    /// # Security note
+    /// Stored verbatim from the YAML. Same path-containment requirement as
+    /// `context` applies.
+    pub dockerfile: PathBuf,
+}
+
+/// A single environment variable entry.
+///
+/// Compose supports two forms:
+/// - `KEY=value` or dict `{KEY: value}` → [`EnvEntry::KeyValue`]
+/// - bare `KEY` (value taken from the host environment at runtime) →
+///   [`EnvEntry::KeyOnly`]
+#[derive(Debug, Clone, PartialEq)]
+pub enum EnvEntry {
+    /// A fully-specified `KEY=value` pair.
+    KeyValue { key: String, value: String },
+    /// A key with no value — the runtime inherits it from the host environment.
+    KeyOnly { key: String },
+}
+
+/// A volume mount specification for a service.
+///
+/// Compose supports three variants:
+/// - **Bind mount** — host path mapped into the container
+/// - **Named volume** — a Docker-managed named volume
+/// - **Anonymous** — no source, just a container path
+#[derive(Debug, Clone, PartialEq)]
+pub enum VolumeSpec {
+    /// A bind mount from a host path into the container.
+    ///
+    /// # Security note
+    /// `host_path` is stored verbatim from the YAML and may contain `..`
+    /// components. It is used only as display/shadow metadata in the preview
+    /// — it must **never** be opened on the host filesystem without first
+    /// canonicalizing and confirming it does not escape the project root.
+    Bind {
+        host_path: PathBuf,
+        container_path: PathBuf,
+        read_only: bool,
+    },
+    /// A named volume (managed by Docker).
+    Named {
+        volume_name: String,
+        container_path: PathBuf,
+        read_only: bool,
+    },
+    /// An anonymous volume with only a container path.
+    Anonymous { container_path: PathBuf },
+}
+
+/// A top-level named volume declaration.
+///
+/// Currently only tracks whether the volume is declared as `external` (i.e.
+/// it must already exist and Compose should not attempt to create it).
+#[derive(Debug, Clone, PartialEq)]
+pub struct VolumeDefinition {
+    /// `true` when `external: true` is set in the volume declaration.
+    pub external: bool,
+}

--- a/src/model/fs.rs
+++ b/src/model/fs.rs
@@ -66,6 +66,18 @@ impl FsNode {
             FsNode::Symlink(s) => &s.provenance,
         }
     }
+
+    /// Return a mutable reference to the provenance record embedded in this node.
+    ///
+    /// Used by the mount shadow engine to attach `MountInfo` to existing nodes
+    /// without cloning the entire node.
+    pub fn provenance_mut(&mut self) -> &mut Provenance {
+        match self {
+            FsNode::File(f) => &mut f.provenance,
+            FsNode::Directory(d) => &mut d.provenance,
+            FsNode::Symlink(s) => &mut s.provenance,
+        }
+    }
 }
 
 /// An in-memory virtual filesystem backed by a flat path-to-node map.
@@ -105,6 +117,14 @@ impl VirtualFs {
     /// Return a reference to the node at `path`, or `None` if it does not exist.
     pub fn get(&self, path: &Path) -> Option<&FsNode> {
         self.nodes.get(path)
+    }
+
+    /// Return a mutable reference to the node at `path`, or `None` if it does not exist.
+    ///
+    /// Used by the mount shadow engine to attach mount metadata to existing nodes
+    /// in-place without re-inserting them.
+    pub fn get_mut(&mut self, path: &Path) -> Option<&mut FsNode> {
+        self.nodes.get_mut(path)
     }
 
     /// Return `true` if a node exists at `path`.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,13 +13,16 @@
 //! | `instruction` | `CopySource`, `Instruction` enum |
 //! | `fs` | `FileNode`, `DirNode`, `SymlinkNode`, `FsNode`, `VirtualFs` |
 //! | `state` | `InstalledRegistry`, `HistoryEntry`, `LayerSummary`, `PreviewState` |
+//! | `compose` | `ComposeFile`, `Service`, `BuildConfig`, `EnvEntry`, `VolumeSpec`, `VolumeDefinition` |
 
+pub mod compose;
 pub mod fs;
 pub mod instruction;
 pub mod provenance;
 pub mod state;
 pub mod warning;
 
+pub use compose::{BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition, VolumeSpec};
 pub use fs::{FsNode, VirtualFs};
 pub use instruction::Instruction;
 pub use provenance::Provenance;

--- a/src/model/provenance.rs
+++ b/src/model/provenance.rs
@@ -30,31 +30,31 @@ pub enum ProvenanceSource {
     EnvSet { key: String, value: String },
 }
 
-/// The type of a Docker mount (`--mount=type=...`).
+/// Metadata about a volume mount that shadows a path in the virtual filesystem.
 ///
-/// Using an enum rather than a free-form string prevents typos at call sites
-/// and allows exhaustive matching in the engine and `:explain` output.
-#[derive(Debug, Clone, PartialEq)]
-pub enum MountKind {
-    /// `--mount=type=bind` — bind-mounts a host path into the build.
-    Bind,
-    /// `--mount=type=volume` — mounts a named volume.
-    Volume,
-    /// `--mount=type=tmpfs` — mounts an ephemeral tmpfs.
-    Tmpfs,
-    /// `--mount=type=cache` — mounts a persistent cache directory.
-    Cache,
-    /// `--mount=type=secret` — mounts a secret file.
-    Secret,
-}
-
-/// Metadata about a bind/volume mount that shadows a path in the virtual filesystem.
+/// `MountInfo` records where a volume mounts inside the container (`container_path`),
+/// whether it is read-only, and a pre-formatted human-readable `description` that is
+/// used by both `:explain` and `:mounts`.  The description is computed from the
+/// `VolumeSpec` variant at the time the mount shadow is applied by `engine::mount`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MountInfo {
-    /// The source of the mount (e.g. host path, named volume, or stage reference).
-    pub source: String,
-    /// The category of mount.
-    pub mount_type: MountKind,
+    /// The absolute container path at which this volume is mounted.
+    pub container_path: PathBuf,
+    /// `true` when the mount was declared `read_only` in the Compose file.
+    pub read_only: bool,
+    /// Pre-formatted human-readable description of the mount source.
+    ///
+    /// # Security note
+    /// This string is assembled from user-controlled YAML content (host paths,
+    /// volume names) and **must** be passed through `sanitize_for_terminal`
+    /// before writing to any terminal output. Callers that skip sanitization
+    /// are vulnerable to ANSI escape injection.
+    ///
+    /// Examples:
+    /// - `"bind mount from ./data"`
+    /// - `"named volume: npm-cache"`
+    /// - `"anonymous volume"`
+    pub description: String,
 }
 
 /// Provenance record attached to every `FsNode`.
@@ -166,35 +166,46 @@ mod tests {
     // --- MountInfo construction ---
 
     #[test]
-    fn mount_info_stores_source_and_kind() {
+    fn mount_info_stores_container_path_and_description() {
         let mount = MountInfo {
-            source: "/host/cache".to_string(),
-            mount_type: MountKind::Bind,
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
         };
-        assert_eq!(mount.source, "/host/cache");
-        assert_eq!(mount.mount_type, MountKind::Bind);
+        assert_eq!(mount.container_path, PathBuf::from("/data"));
+        assert!(!mount.read_only);
+        assert_eq!(mount.description, "bind mount from ./data");
     }
 
     #[test]
-    fn all_mount_kinds_are_mutually_distinct() {
-        let kinds = [
-            MountKind::Bind,
-            MountKind::Volume,
-            MountKind::Tmpfs,
-            MountKind::Cache,
-            MountKind::Secret,
-        ];
-        // Every pair must be distinct — catches any accidental mapping of
-        // multiple variants to the same underlying discriminant.
-        for i in 0..kinds.len() {
-            for j in 0..kinds.len() {
-                if i == j {
-                    assert_eq!(kinds[i], kinds[j], "variant {i} should equal itself");
-                } else {
-                    assert_ne!(kinds[i], kinds[j], "variants {i} and {j} must be distinct");
-                }
-            }
-        }
+    fn mount_info_read_only_flag() {
+        let mount = MountInfo {
+            container_path: PathBuf::from("/cache"),
+            read_only: true,
+            description: "named volume: my-cache".to_string(),
+        };
+        assert!(mount.read_only);
+    }
+
+    #[test]
+    fn mount_info_anonymous_volume_description() {
+        let mount = MountInfo {
+            container_path: PathBuf::from("/tmp/scratch"),
+            read_only: false,
+            description: "anonymous volume".to_string(),
+        };
+        assert_eq!(mount.description, "anonymous volume");
+    }
+
+    #[test]
+    fn mount_info_clone_is_independent() {
+        let original = MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
+        };
+        let clone = original.clone();
+        assert_eq!(original, clone);
     }
 
     // --- Provenance::new ---

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use super::fs::VirtualFs;
+use super::provenance::MountInfo;
 use super::warning::Warning;
 
 /// A registry of all completed build stages, indexed by name and by number.
@@ -222,6 +223,13 @@ pub struct PreviewState {
 
     /// The currently active build stage alias, if any (used for multi-stage builds).
     pub active_stage: Option<String>,
+
+    /// Volume mount shadows applied by the Compose engine.
+    ///
+    /// Each entry records a volume mount declared in the Compose service definition.
+    /// Populated by `engine::mount::apply_mount_shadows` after the Dockerfile pipeline runs.
+    /// Used by the `:mounts` REPL command to list active mount shadows.
+    pub mounts: Vec<MountInfo>,
 }
 
 impl Default for PreviewState {
@@ -239,6 +247,7 @@ impl Default for PreviewState {
             layers: Vec::new(),
             warnings: Vec::new(),
             active_stage: None,
+            mounts: Vec::new(),
         }
     }
 }

--- a/src/model/warning.rs
+++ b/src/model/warning.rs
@@ -134,6 +134,16 @@ pub enum Warning {
         /// The environment variable key that had no value.
         key: String,
     },
+
+    /// A Compose `working_dir` with `..` components would have escaped the
+    /// virtual filesystem root `/`.
+    ///
+    /// The path is clamped to `/` and the REPL continues. The user should be
+    /// aware that the CWD they see may differ from what Docker would compute.
+    WorkdirEscapedRoot {
+        /// The raw (unnormalized) path from the Compose YAML.
+        path: PathBuf,
+    },
 }
 
 /// # Terminal output safety
@@ -213,6 +223,13 @@ impl fmt::Display for Warning {
             }
             Warning::UnresolvedEnvKey { key } => {
                 write!(f, "environment key '{}' has no value — skipped", key)
+            }
+            Warning::WorkdirEscapedRoot { path } => {
+                write!(
+                    f,
+                    "working_dir '{}' escapes the virtual root — clamped to /",
+                    path.display()
+                )
             }
         }
     }
@@ -750,5 +767,42 @@ mod tests {
         assert_eq!(w2.clone(), w2);
         assert_eq!(w3.clone(), w3);
         assert_ne!(w1, w3);
+    }
+
+    // --- WorkdirEscapedRoot ---
+
+    #[test]
+    fn workdir_escaped_root_stores_path() {
+        let w = Warning::WorkdirEscapedRoot {
+            path: PathBuf::from("../../../etc"),
+        };
+        assert_eq!(
+            w,
+            Warning::WorkdirEscapedRoot {
+                path: PathBuf::from("../../../etc")
+            }
+        );
+    }
+
+    #[test]
+    fn display_workdir_escaped_root_contains_path_and_clamped() {
+        let w = Warning::WorkdirEscapedRoot {
+            path: PathBuf::from("../../../etc"),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(
+            s.contains("../../../etc"),
+            "must contain original path; got: {s}"
+        );
+        assert!(s.contains("clamped"), "must mention clamping; got: {s}");
+    }
+
+    #[test]
+    fn workdir_escaped_root_clone_produces_equal_value() {
+        let w = Warning::WorkdirEscapedRoot {
+            path: PathBuf::from("../../bad"),
+        };
+        assert_eq!(w.clone(), w);
     }
 }

--- a/src/model/warning.rs
+++ b/src/model/warning.rs
@@ -107,6 +107,33 @@ pub enum Warning {
         /// Source line number (1-based) where the COPY instruction appeared.
         line: usize,
     },
+
+    /// A Compose service uses `image:` but has no `build:` context.
+    ///
+    /// The preview filesystem starts empty because the engine does not extract
+    /// real image filesystems. The REPL remains functional but shows no files.
+    ImageOnlyService {
+        /// The image reference from the service's `image:` field.
+        image: String,
+    },
+
+    /// An `env_file` referenced in a Compose service definition was not found.
+    ///
+    /// The missing file is skipped and the remaining env_files and environment
+    /// entries are still applied. The REPL continues normally.
+    EnvFileNotFound {
+        /// The path that was referenced but could not be read.
+        path: PathBuf,
+    },
+
+    /// A Compose `environment` entry used the bare `KEY` form (no value).
+    ///
+    /// At preview time the host environment is not available, so the key is
+    /// skipped rather than inserted with an empty or incorrect value.
+    UnresolvedEnvKey {
+        /// The environment variable key that had no value.
+        key: String,
+    },
 }
 
 /// # Terminal output safety
@@ -173,6 +200,19 @@ impl fmt::Display for Warning {
                     "COPY --from='{}' references unknown stage at line {} (skipped)",
                     stage, line
                 )
+            }
+            Warning::ImageOnlyService { image } => {
+                write!(
+                    f,
+                    "service uses image '{}' with no build context — filesystem is empty",
+                    image
+                )
+            }
+            Warning::EnvFileNotFound { path } => {
+                write!(f, "env_file '{}' not found — skipped", path.display())
+            }
+            Warning::UnresolvedEnvKey { key } => {
+                write!(f, "environment key '{}' has no value — skipped", key)
             }
         }
     }
@@ -576,5 +616,139 @@ mod tests {
             line: 5,
         };
         assert_eq!(w.clone(), w);
+    }
+
+    // --- ImageOnlyService ---
+
+    #[test]
+    fn image_only_service_stores_image() {
+        let w = Warning::ImageOnlyService {
+            image: "postgres:15".to_string(),
+        };
+        assert_eq!(
+            w,
+            Warning::ImageOnlyService {
+                image: "postgres:15".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn display_image_only_service_contains_image_name() {
+        let w = Warning::ImageOnlyService {
+            image: "postgres:15".to_string(),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(
+            s.contains("postgres:15"),
+            "display must contain image name, got: {s}"
+        );
+        assert!(
+            s.contains("filesystem is empty"),
+            "display must mention empty filesystem, got: {s}"
+        );
+    }
+
+    #[test]
+    fn display_image_only_service_full_string() {
+        let w = Warning::ImageOnlyService {
+            image: "redis:7".to_string(),
+        };
+        assert_eq!(
+            w.to_string(),
+            "service uses image 'redis:7' with no build context \u{2014} filesystem is empty"
+        );
+    }
+
+    // --- EnvFileNotFound ---
+
+    #[test]
+    fn env_file_not_found_stores_path() {
+        let path = PathBuf::from("/project/.env.prod");
+        let w = Warning::EnvFileNotFound { path: path.clone() };
+        assert_eq!(w, Warning::EnvFileNotFound { path });
+    }
+
+    #[test]
+    fn display_env_file_not_found_contains_path() {
+        let w = Warning::EnvFileNotFound {
+            path: PathBuf::from("/project/.env"),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(s.contains(".env"), "display must contain path, got: {s}");
+        assert!(
+            s.contains("not found"),
+            "display must say 'not found', got: {s}"
+        );
+    }
+
+    #[test]
+    fn display_env_file_not_found_full_string() {
+        let w = Warning::EnvFileNotFound {
+            path: PathBuf::from(".env"),
+        };
+        assert_eq!(w.to_string(), "env_file '.env' not found \u{2014} skipped");
+    }
+
+    // --- UnresolvedEnvKey ---
+
+    #[test]
+    fn unresolved_env_key_stores_key() {
+        let w = Warning::UnresolvedEnvKey {
+            key: "HOST_TOKEN".to_string(),
+        };
+        assert_eq!(
+            w,
+            Warning::UnresolvedEnvKey {
+                key: "HOST_TOKEN".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn display_unresolved_env_key_contains_key_name() {
+        let w = Warning::UnresolvedEnvKey {
+            key: "SECRET".to_string(),
+        };
+        let s = w.to_string();
+        assert!(!s.is_empty());
+        assert!(
+            s.contains("SECRET"),
+            "display must contain key name, got: {s}"
+        );
+        assert!(
+            s.contains("no value"),
+            "display must mention 'no value', got: {s}"
+        );
+    }
+
+    #[test]
+    fn display_unresolved_env_key_full_string() {
+        let w = Warning::UnresolvedEnvKey {
+            key: "MY_VAR".to_string(),
+        };
+        assert_eq!(
+            w.to_string(),
+            "environment key 'MY_VAR' has no value \u{2014} skipped"
+        );
+    }
+
+    #[test]
+    fn new_warning_variants_clone_and_equal() {
+        let w1 = Warning::ImageOnlyService {
+            image: "img".to_string(),
+        };
+        let w2 = Warning::EnvFileNotFound {
+            path: PathBuf::from("/a"),
+        };
+        let w3 = Warning::UnresolvedEnvKey {
+            key: "K".to_string(),
+        };
+        assert_eq!(w1.clone(), w1);
+        assert_eq!(w2.clone(), w2);
+        assert_eq!(w3.clone(), w3);
+        assert_ne!(w1, w3);
     }
 }

--- a/src/parser/compose.rs
+++ b/src/parser/compose.rs
@@ -1,0 +1,738 @@
+//! Parser for `docker-compose.yml` files.
+//!
+//! # Design
+//!
+//! Compose YAML uses "dual-form" fields extensively: `build` can be a plain
+//! string or a map; `environment` can be a list or a dict; `depends_on` can
+//! be a list or a map; etc.  Serde handles this through `#[serde(untagged)]`
+//! enums defined *privately* in this module.  The public surface only exposes
+//! the clean domain types from [`crate::model::compose`].
+//!
+//! # Entry point
+//!
+//! [`parse_compose`] is the single public function.  It deserialises the raw
+//! YAML into private intermediate types, validates required keys, then
+//! converts everything into the domain model.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::model::compose::{
+    BuildConfig, ComposeFile, EnvEntry, Service, VolumeDefinition, VolumeSpec,
+};
+use crate::parser::error::ComposeParseError;
+
+// ---------------------------------------------------------------------------
+// Private serde intermediate types
+// ---------------------------------------------------------------------------
+
+/// Top-level Compose file structure.
+///
+/// `services` is `Option` so we can detect its absence and return
+/// [`ComposeParseError::MissingServicesKey`] rather than a confusing YAML
+/// error.  Unknown top-level keys (e.g. `networks:`, `version:`) are ignored
+/// thanks to `#[serde(default)]` and the lack of `deny_unknown_fields`.
+#[derive(Deserialize, Default)]
+struct RawComposeFile {
+    services: Option<BTreeMap<String, RawService>>,
+    #[serde(default)]
+    volumes: BTreeMap<String, Option<RawVolumeDefinition>>,
+}
+
+/// Raw service definition — all fields are optional so we never fail on an
+/// unknown or absent key.
+#[derive(Deserialize, Default)]
+struct RawService {
+    build: Option<RawBuild>,
+    image: Option<String>,
+    #[serde(default)]
+    environment: Option<RawEnv>,
+    #[serde(default)]
+    env_file: Option<RawEnvFile>,
+    #[serde(default)]
+    volumes: Vec<RawVolumeSpec>,
+    working_dir: Option<String>,
+    #[serde(default)]
+    depends_on: Option<RawDependsOn>,
+    #[serde(default)]
+    ports: Vec<String>,
+}
+
+/// `build` can be a plain string (short form) or a map (long form).
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawBuild {
+    /// Short form: `build: ./app`
+    Short(String),
+    /// Long form: `build: { context: ./app, dockerfile: Dockerfile.dev }`
+    Full {
+        context: String,
+        #[serde(default = "default_dockerfile")]
+        dockerfile: String,
+    },
+}
+
+fn default_dockerfile() -> String {
+    "Dockerfile".to_string()
+}
+
+/// `environment` can be a list of strings or a mapping.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawEnv {
+    /// List form: `- KEY=value` or `- KEY`
+    List(Vec<String>),
+    /// Dict form: `KEY: value` (values may be strings, numbers, bools)
+    Dict(BTreeMap<String, serde_yaml::Value>),
+}
+
+/// `env_file` can be a single string or a list.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawEnvFile {
+    Single(String),
+    List(Vec<String>),
+}
+
+/// `depends_on` can be a list of service names or a map with condition objects.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawDependsOn {
+    List(Vec<String>),
+    /// Dict form: `depends_on: { db: { condition: service_healthy } }`
+    /// We only collect the keys (service names); conditions are not modelled.
+    Dict(BTreeMap<String, serde_yaml::Value>),
+}
+
+/// A single volume spec in the per-service `volumes:` list.
+///
+/// Each entry is either a short string (`"./src:/app:ro"`) or a long map form.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawVolumeSpec {
+    Short(String),
+    Long {
+        #[serde(rename = "type")]
+        kind: String,
+        source: Option<String>,
+        target: String,
+        #[serde(default)]
+        read_only: bool,
+    },
+}
+
+/// A top-level named volume declaration.  May be `null` (bare name) or a map.
+#[derive(Deserialize, Default)]
+struct RawVolumeDefinition {
+    #[serde(default)]
+    external: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Parse a `docker-compose.yml` file from a string slice.
+///
+/// Returns a [`ComposeFile`] on success, or a [`ComposeParseError`] describing
+/// the first structural problem encountered.
+///
+/// Unknown YAML keys (e.g. `networks:`, `restart:`, `healthcheck:`) are
+/// silently ignored so that real-world Compose files remain usable even when
+/// they use features that `demu` does not yet model.
+pub fn parse_compose(input: &str) -> Result<ComposeFile, ComposeParseError> {
+    // Deserialise raw YAML into the intermediate representation.
+    let raw: RawComposeFile =
+        serde_yaml::from_str(input).map_err(|e| ComposeParseError::InvalidYaml {
+            message: e.to_string(),
+        })?;
+
+    // `services:` is required — fail with a clear message if absent.
+    let raw_services = raw.services.ok_or(ComposeParseError::MissingServicesKey)?;
+
+    // Convert each raw service into the domain model.
+    let mut services = BTreeMap::new();
+    for (name, raw_svc) in raw_services {
+        let service = convert_service(name.clone(), raw_svc)?;
+        services.insert(name, service);
+    }
+
+    // Convert top-level volume declarations.
+    let volumes = raw
+        .volumes
+        .into_iter()
+        .map(|(name, raw_vol)| {
+            let def = VolumeDefinition {
+                external: raw_vol.map(|v| v.external).unwrap_or(false),
+            };
+            (name, def)
+        })
+        .collect();
+
+    Ok(ComposeFile { services, volumes })
+}
+
+// ---------------------------------------------------------------------------
+// Private conversion helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a [`RawService`] into a [`Service`] domain type.
+fn convert_service(name: String, raw: RawService) -> Result<Service, ComposeParseError> {
+    let build = raw.build.map(convert_build);
+    let environment = convert_env(raw.environment);
+    let env_file = convert_env_file(raw.env_file);
+    let volumes = raw
+        .volumes
+        .into_iter()
+        .map(|v| convert_volume_spec(v, &name))
+        .collect::<Result<Vec<_>, _>>()?;
+    let depends_on = convert_depends_on(raw.depends_on);
+
+    Ok(Service {
+        name,
+        build,
+        image: raw.image,
+        environment,
+        env_file,
+        volumes,
+        working_dir: raw.working_dir.map(PathBuf::from),
+        depends_on,
+        ports: raw.ports,
+    })
+}
+
+/// Convert a [`RawBuild`] into a [`BuildConfig`].
+fn convert_build(raw: RawBuild) -> BuildConfig {
+    match raw {
+        RawBuild::Short(ctx) => BuildConfig {
+            context: PathBuf::from(&ctx),
+            dockerfile: PathBuf::from("Dockerfile"),
+        },
+        RawBuild::Full {
+            context,
+            dockerfile,
+        } => BuildConfig {
+            context: PathBuf::from(context),
+            dockerfile: PathBuf::from(dockerfile),
+        },
+    }
+}
+
+/// Convert a [`RawEnv`] (or absent value) into a list of [`EnvEntry`] items.
+fn convert_env(raw: Option<RawEnv>) -> Vec<EnvEntry> {
+    match raw {
+        None => vec![],
+        Some(RawEnv::List(items)) => items.into_iter().map(parse_env_string).collect(),
+        Some(RawEnv::Dict(map)) => map
+            .into_iter()
+            .map(|(k, v)| EnvEntry::KeyValue {
+                key: k,
+                value: yaml_value_to_string(v),
+            })
+            .collect(),
+    }
+}
+
+/// Parse a single environment string in `KEY` or `KEY=value` form.
+fn parse_env_string(s: String) -> EnvEntry {
+    // Split on the *first* `=` only so that values containing `=` are
+    // preserved intact (e.g. `BASE64=abc=def`).
+    match s.split_once('=') {
+        Some((key, value)) => EnvEntry::KeyValue {
+            key: key.to_string(),
+            value: value.to_string(),
+        },
+        None => EnvEntry::KeyOnly { key: s },
+    }
+}
+
+/// Convert a `serde_yaml::Value` to a string representation.
+///
+/// This handles the common case of numeric and boolean values appearing in
+/// the `environment` dict form (e.g. `PORT: 3000`).
+fn yaml_value_to_string(v: serde_yaml::Value) -> String {
+    match v {
+        serde_yaml::Value::String(s) => s,
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        serde_yaml::Value::Null => String::new(),
+        // Nested sequences/mappings are stringified as YAML — unusual but valid.
+        // `serde_yaml::to_string` is infallible in practice; the empty-string
+        // fallback is a last resort that should never be reached for well-formed
+        // serde_yaml Values. `.trim()` removes the trailing newline that
+        // serde_yaml always appends.
+        other => serde_yaml::to_string(&other)
+            .unwrap_or_else(|_| "<unserializable>".to_string())
+            .trim()
+            .to_string(),
+    }
+}
+
+/// Convert a [`RawEnvFile`] (or absent value) into a list of [`PathBuf`]s.
+fn convert_env_file(raw: Option<RawEnvFile>) -> Vec<PathBuf> {
+    match raw {
+        None => vec![],
+        Some(RawEnvFile::Single(s)) => vec![PathBuf::from(s)],
+        Some(RawEnvFile::List(items)) => items.into_iter().map(PathBuf::from).collect(),
+    }
+}
+
+/// Convert a [`RawDependsOn`] (or absent value) into a list of service name
+/// strings.
+fn convert_depends_on(raw: Option<RawDependsOn>) -> Vec<String> {
+    match raw {
+        None => vec![],
+        Some(RawDependsOn::List(items)) => items,
+        Some(RawDependsOn::Dict(map)) => map.into_keys().collect(),
+    }
+}
+
+/// Convert a [`RawVolumeSpec`] into a [`VolumeSpec`] domain type.
+///
+/// Returns an error only when the long form specifies an unrecognised `type`
+/// value — in practice this should not happen with valid Compose files.
+fn convert_volume_spec(
+    raw: RawVolumeSpec,
+    service_name: &str,
+) -> Result<VolumeSpec, ComposeParseError> {
+    match raw {
+        RawVolumeSpec::Short(s) => Ok(parse_volume_short(&s)),
+        RawVolumeSpec::Long {
+            kind,
+            source,
+            target,
+            read_only,
+        } => {
+            match kind.as_str() {
+                "bind" => {
+                    // Long-form bind requires a source.
+                    let host_path = source.map(PathBuf::from).ok_or_else(|| {
+                        ComposeParseError::InvalidService {
+                            name: service_name.to_string(),
+                            message: "bind volume missing 'source'".to_string(),
+                        }
+                    })?;
+                    Ok(VolumeSpec::Bind {
+                        host_path,
+                        container_path: PathBuf::from(target),
+                        read_only,
+                    })
+                }
+                "volume" => {
+                    let volume_name = source.unwrap_or_default();
+                    if volume_name.is_empty() {
+                        Ok(VolumeSpec::Anonymous {
+                            container_path: PathBuf::from(target),
+                        })
+                    } else {
+                        Ok(VolumeSpec::Named {
+                            volume_name,
+                            container_path: PathBuf::from(target),
+                            read_only,
+                        })
+                    }
+                }
+                // Unknown long-form type — treat as anonymous with the target
+                // path so the file is still usable.
+                _ => Ok(VolumeSpec::Anonymous {
+                    container_path: PathBuf::from(target),
+                }),
+            }
+        }
+    }
+}
+
+/// Parse the short volume syntax `[source:]target[:options]`.
+///
+/// Classification rules:
+/// - No source → `Anonymous`
+/// - Source starts with `.` or `/` → `Bind` (host path)
+/// - Otherwise → `Named` (Docker-managed named volume)
+fn parse_volume_short(s: &str) -> VolumeSpec {
+    // Options are always the last colon-separated token when present.
+    // We need to be careful: an absolute path like `/host/path:/app` has three
+    // parts but no options; `./src:/app:ro` has three parts with options.
+    let parts: Vec<&str> = s.splitn(3, ':').collect();
+
+    match parts.as_slice() {
+        // Single segment → anonymous volume.
+        [target] => VolumeSpec::Anonymous {
+            container_path: PathBuf::from(*target),
+        },
+        // Two segments → source:target, no options.
+        [source, target] => classify_source(source, target, false),
+        // Three segments → source:target:options.
+        [source, target, options] => {
+            let read_only = *options == "ro";
+            classify_source(source, target, read_only)
+        }
+        // Unreachable with splitn(3) but satisfies exhaustiveness.
+        _ => VolumeSpec::Anonymous {
+            container_path: PathBuf::from(s),
+        },
+    }
+}
+
+/// Classify a volume source string as a bind mount or a named volume.
+///
+/// Docker Compose treats sources starting with `.`, `/`, or `~` as host paths
+/// (bind mounts). Everything else is a named volume.
+fn classify_source(source: &str, target: &str, read_only: bool) -> VolumeSpec {
+    if source.starts_with('.') || source.starts_with('/') || source.starts_with('~') {
+        VolumeSpec::Bind {
+            host_path: PathBuf::from(source),
+            container_path: PathBuf::from(target),
+            read_only,
+        }
+    } else {
+        VolumeSpec::Named {
+            volume_name: source.to_string(),
+            container_path: PathBuf::from(target),
+            read_only,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Volume short-syntax tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_volume_short_bind() {
+        // Relative source path → Bind mount, not read-only.
+        let spec = parse_volume_short("./src:/app/src");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./src"),
+                container_path: PathBuf::from("/app/src"),
+                read_only: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_bind_readonly() {
+        // `:ro` suffix → read_only true.
+        let spec = parse_volume_short("./src:/app/src:ro");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./src"),
+                container_path: PathBuf::from("/app/src"),
+                read_only: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_named() {
+        // Non-path source → Named volume.
+        let spec = parse_volume_short("data:/var/lib/data");
+        assert_eq!(
+            spec,
+            VolumeSpec::Named {
+                volume_name: "data".to_string(),
+                container_path: PathBuf::from("/var/lib/data"),
+                read_only: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_anonymous() {
+        // Single path with no source → Anonymous.
+        let spec = parse_volume_short("/app/cache");
+        assert_eq!(
+            spec,
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/app/cache"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_volume_short_absolute_bind() {
+        // Absolute host path → Bind mount.
+        let spec = parse_volume_short("/host/path:/app");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("/host/path"),
+                container_path: PathBuf::from("/app"),
+                read_only: false,
+            }
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Environment entry parsing tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_env_list_key_value() {
+        let entry = parse_env_string("KEY=value".to_string());
+        assert_eq!(
+            entry,
+            EnvEntry::KeyValue {
+                key: "KEY".to_string(),
+                value: "value".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_env_list_key_only() {
+        let entry = parse_env_string("KEY".to_string());
+        assert_eq!(
+            entry,
+            EnvEntry::KeyOnly {
+                key: "KEY".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_env_dict_string_value() {
+        // Dict form with a plain string value.
+        let yaml = "services:\n  svc:\n    environment:\n      KEY: val\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert!(svc.environment.contains(&EnvEntry::KeyValue {
+            key: "KEY".to_string(),
+            value: "val".to_string(),
+        }));
+    }
+
+    #[test]
+    fn parse_env_dict_numeric_value() {
+        // Numeric values in the dict form must be stringified.
+        let yaml = "services:\n  svc:\n    environment:\n      PORT: 3000\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert!(svc.environment.contains(&EnvEntry::KeyValue {
+            key: "PORT".to_string(),
+            value: "3000".to_string(),
+        }));
+    }
+
+    // ------------------------------------------------------------------
+    // Build config tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn build_string_shorthand() {
+        // Short-form string → dockerfile defaults to "Dockerfile".
+        let yaml = "services:\n  api:\n    build: ./app\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        let build = svc.build.as_ref().expect("build present");
+        assert_eq!(build.context, PathBuf::from("./app"));
+        assert_eq!(build.dockerfile, PathBuf::from("Dockerfile"));
+    }
+
+    #[test]
+    fn build_map_with_dockerfile() {
+        // Long-form map → explicit dockerfile path preserved.
+        let yaml = "services:\n  api:\n    build:\n      context: ./app\n      dockerfile: Dockerfile.dev\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        let build = svc.build.as_ref().expect("build present");
+        assert_eq!(build.context, PathBuf::from("./app"));
+        assert_eq!(build.dockerfile, PathBuf::from("Dockerfile.dev"));
+    }
+
+    // ------------------------------------------------------------------
+    // depends_on tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn depends_on_list() {
+        let yaml =
+            "services:\n  api:\n    image: nginx\n    depends_on:\n      - db\n      - cache\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        let mut deps = svc.depends_on.clone();
+        deps.sort();
+        assert_eq!(deps, vec!["cache", "db"]);
+    }
+
+    #[test]
+    fn depends_on_dict() {
+        // Dict form — only service names (keys) should be collected.
+        let yaml =
+            "services:\n  api:\n    image: nginx\n    depends_on:\n      db:\n        condition: service_healthy\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("api").expect("api present");
+        assert_eq!(svc.depends_on, vec!["db"]);
+    }
+
+    // ------------------------------------------------------------------
+    // env_file tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn env_file_string() {
+        let yaml = "services:\n  svc:\n    image: nginx\n    env_file: .env\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(svc.env_file, vec![PathBuf::from(".env")]);
+    }
+
+    #[test]
+    fn env_file_list() {
+        let yaml =
+            "services:\n  svc:\n    image: nginx\n    env_file:\n      - .env\n      - .env.local\n";
+        let file = parse_compose(yaml).expect("should parse");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.env_file,
+            vec![PathBuf::from(".env"), PathBuf::from(".env.local")]
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Error case tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn missing_services_key() {
+        // Valid YAML but no `services:` → MissingServicesKey.
+        let yaml = "version: \"3.8\"\nnetworks:\n  default:\n";
+        let err = parse_compose(yaml).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeParseError::MissingServicesKey),
+            "unexpected error variant: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_yaml() {
+        // Syntactically broken YAML → InvalidYaml.
+        let yaml = "services:\n  api:\n    build: [unclosed\n";
+        let err = parse_compose(yaml).expect_err("should fail");
+        assert!(
+            matches!(err, ComposeParseError::InvalidYaml { .. }),
+            "unexpected error variant: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_keys_tolerated() {
+        // Extra keys like `networks:` and `restart:` must not cause errors.
+        let yaml =
+            "services:\n  svc:\n    image: nginx\n    restart: always\nnetworks:\n  default:\n";
+        let result = parse_compose(yaml);
+        assert!(result.is_ok(), "should tolerate unknown keys: {result:?}");
+    }
+
+    // ------------------------------------------------------------------
+    // Volume short-syntax: tilde home-directory prefix
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_volume_short_tilde_is_bind() {
+        // `~` prefix must be classified as a Bind mount, not a Named volume.
+        let spec = parse_volume_short("~/projects/app:/app");
+        assert_eq!(
+            spec,
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("~/projects/app"),
+                container_path: PathBuf::from("/app"),
+                read_only: false,
+            },
+            "tilde-prefixed source must be Bind, not Named"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Long-form volume syntax tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn volume_long_form_bind_happy_path() {
+        // Long-form bind with source present → Bind variant.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: bind\n        source: ./src\n        target: /app/src\n        read_only: true\n";
+        let file = parse_compose(yaml).expect("should parse long-form bind");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(svc.volumes.len(), 1);
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Bind {
+                host_path: PathBuf::from("./src"),
+                container_path: PathBuf::from("/app/src"),
+                read_only: true,
+            }
+        );
+    }
+
+    #[test]
+    fn volume_long_form_bind_missing_source_returns_invalid_service() {
+        // Long-form bind with no source → InvalidService error.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: bind\n        target: /app/src\n";
+        let err = parse_compose(yaml).expect_err("should fail with missing source");
+        assert!(
+            matches!(
+                &err,
+                ComposeParseError::InvalidService { name, message }
+                    if name == "svc" && message.contains("bind volume missing")
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn volume_long_form_named_with_source() {
+        // Long-form volume type with source → Named variant.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: volume\n        source: mydata\n        target: /var/lib/data\n";
+        let file = parse_compose(yaml).expect("should parse long-form named");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Named {
+                volume_name: "mydata".to_string(),
+                container_path: PathBuf::from("/var/lib/data"),
+                read_only: false,
+            }
+        );
+    }
+
+    #[test]
+    fn volume_long_form_volume_without_source_is_anonymous() {
+        // Long-form volume type with no source → Anonymous variant.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: volume\n        target: /tmp/cache\n";
+        let file = parse_compose(yaml).expect("should parse long-form anonymous");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/tmp/cache"),
+            }
+        );
+    }
+
+    #[test]
+    fn volume_long_form_unknown_kind_falls_back_to_anonymous() {
+        // Unknown `type` string → Anonymous fallback, no error.
+        let yaml = "services:\n  svc:\n    image: nginx\n    volumes:\n      - type: tmpfs\n        target: /tmp\n";
+        let file = parse_compose(yaml).expect("should tolerate unknown volume type");
+        let svc = file.services.get("svc").expect("svc present");
+        assert_eq!(
+            svc.volumes[0],
+            VolumeSpec::Anonymous {
+                container_path: PathBuf::from("/tmp"),
+            }
+        );
+    }
+}

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -10,3 +10,23 @@ pub enum ParseError {
     #[error("line {line}: {message}")]
     InvalidInstruction { line: usize, message: String },
 }
+
+/// Errors produced by the Compose YAML parser.
+///
+/// Variants distinguish structural problems (missing keys, invalid service
+/// definitions) from low-level YAML syntax errors so callers can surface
+/// meaningful messages to the user.
+#[derive(Debug, Error)]
+pub enum ComposeParseError {
+    /// The YAML could not be parsed at all (syntax error or type mismatch).
+    #[error("invalid YAML: {message}")]
+    InvalidYaml { message: String },
+
+    /// The top-level `services:` key is absent from the Compose file.
+    #[error("compose file is missing the 'services' key")]
+    MissingServicesKey,
+
+    /// A service definition is structurally invalid.
+    #[error("invalid service '{name}': {message}")]
+    InvalidService { name: String, message: String },
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,9 @@
 //! Turns Dockerfile and Compose files into typed instruction models.
 
+pub mod compose;
 pub mod dockerfile;
 pub mod error;
 
+pub use compose::parse_compose;
 pub use dockerfile::parse_dockerfile;
-pub use error::ParseError;
+pub use error::{ComposeParseError, ParseError};

--- a/src/repl/commands/cat.rs
+++ b/src/repl/commands/cat.rs
@@ -36,7 +36,7 @@ pub fn execute(state: &PreviewState, path: &str, writer: &mut impl Write) -> Res
             // Use lossy conversion so non-UTF-8 bytes are displayed as U+FFFD
             // rather than causing a panic or hard error.
             let content = String::from_utf8_lossy(&f.content);
-            write!(writer, "{content}").map_err(|e| ReplError::InvalidArguments {
+            write!(writer, "{content}").map_err(|e| ReplError::Io {
                 command: "cat".to_string(),
                 message: e.to_string(),
             })
@@ -54,11 +54,9 @@ pub fn execute(state: &PreviewState, path: &str, writer: &mut impl Write) -> Res
             } else {
                 " (symlink, follow manually)"
             };
-            writeln!(writer, "-> {}{note}", s.target.display()).map_err(|e| {
-                ReplError::InvalidArguments {
-                    command: "cat".to_string(),
-                    message: e.to_string(),
-                }
+            writeln!(writer, "-> {}{note}", s.target.display()).map_err(|e| ReplError::Io {
+                command: "cat".to_string(),
+                message: e.to_string(),
             })
         }
         None => Err(ReplError::PathNotFound { path: resolved }),

--- a/src/repl/commands/find.rs
+++ b/src/repl/commands/find.rs
@@ -64,7 +64,7 @@ pub fn execute(
     matches.sort();
 
     for m in &matches {
-        writeln!(writer, "{m}").map_err(|e| ReplError::InvalidArguments {
+        writeln!(writer, "{m}").map_err(|e| ReplError::Io {
             command: "find".to_string(),
             message: e.to_string(),
         })?;

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -39,6 +39,8 @@ CUSTOM COMMANDS (prefix with :)
   :warnings                show simulation warnings
   :reload                  re-read and re-process the Dockerfile
   :mounts                  list volume mount shadows (Compose mode)
+  :services                list all Compose services (Compose mode)
+  :depends                 show dependency tree (Compose mode)
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
@@ -145,6 +147,22 @@ mod tests {
         assert!(
             run().contains(":mounts"),
             "output must mention ':mounts' in the custom commands section"
+        );
+    }
+
+    #[test]
+    fn help_contains_services() {
+        assert!(
+            run().contains(":services"),
+            "output must mention ':services' in the custom commands section"
+        );
+    }
+
+    #[test]
+    fn help_contains_depends() {
+        assert!(
+            run().contains(":depends"),
+            "output must mention ':depends' in the custom commands section"
         );
     }
 }

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -44,7 +44,7 @@ CUSTOM COMMANDS (prefix with :)
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
-    write!(writer, "{help_text}").map_err(|e| ReplError::InvalidArguments {
+    write!(writer, "{help_text}").map_err(|e| ReplError::Io {
         command: "help".to_string(),
         message: e.to_string(),
     })

--- a/src/repl/commands/help.rs
+++ b/src/repl/commands/help.rs
@@ -38,6 +38,7 @@ CUSTOM COMMANDS (prefix with :)
   :installed               show simulated package installs
   :warnings                show simulation warnings
   :reload                  re-read and re-process the Dockerfile
+  :mounts                  list volume mount shadows (Compose mode)
 
 NOTE: demu is a preview shell. Commands show simulated state, not real containers.
 ";
@@ -136,6 +137,14 @@ mod tests {
         assert!(
             run().contains(":reload"),
             "output must mention ':reload' in the custom commands section"
+        );
+    }
+
+    #[test]
+    fn help_contains_mounts() {
+        assert!(
+            run().contains(":mounts"),
+            "output must mention ':mounts' in the custom commands section"
         );
     }
 }

--- a/src/repl/commands/ls.rs
+++ b/src/repl/commands/ls.rs
@@ -62,7 +62,7 @@ pub fn execute(
             .and_then(|n| n.to_str())
             .unwrap_or("?");
 
-        format_entry(name, node, long, writer).map_err(|e| ReplError::InvalidArguments {
+        format_entry(name, node, long, writer).map_err(|e| ReplError::Io {
             command: "ls".to_string(),
             message: e.to_string(),
         })?;

--- a/src/repl/commands/pwd.rs
+++ b/src/repl/commands/pwd.rs
@@ -14,7 +14,7 @@ use crate::repl::error::ReplError;
 /// followed by a newline. The command never fails.
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Display the cwd as a string; PathBuf::display() is safe on all platforms.
-    writeln!(writer, "{}", state.cwd.display()).map_err(|e| ReplError::InvalidArguments {
+    writeln!(writer, "{}", state.cwd.display()).map_err(|e| ReplError::Io {
         command: "pwd".to_string(),
         message: e.to_string(),
     })

--- a/src/repl/config.rs
+++ b/src/repl/config.rs
@@ -6,16 +6,31 @@
 
 use std::path::PathBuf;
 
+use crate::model::compose::ComposeFile;
+
+/// Holds the Compose file and the currently selected service name for sessions
+/// that were started with `--compose`.
+///
+/// Stored in `ReplConfig` so that `:reload` can re-parse the Compose file and
+/// future commands such as `:services`, `:mounts`, and `:depends` can access
+/// the full service graph.
+pub struct ComposeContext {
+    /// The fully parsed Compose file.
+    pub compose_file: ComposeFile,
+    /// The name of the service selected via `--service`.
+    pub selected_service: String,
+}
+
 /// Session-level configuration for the REPL.
 ///
 /// Holds the fixed session metadata (Dockerfile path, build context directory,
-/// and optional stage selection) that the REPL needs to support `:reload`.
-/// These values are immutable after construction and are separate from
-/// `PreviewState`, which holds simulation output.
+/// optional stage selection, and optional Compose context) that the REPL needs
+/// to support `:reload`. These values are immutable after construction and are
+/// separate from `PreviewState`, which holds simulation output.
 pub struct ReplConfig {
-    /// Absolute path to the Dockerfile being previewed.
+    /// Absolute path to the Dockerfile or Compose file being previewed.
     pub dockerfile_path: PathBuf,
-    /// Absolute path to the build context directory (parent of the Dockerfile).
+    /// Absolute path to the build context directory (parent of the file).
     ///
     /// Derived automatically from `dockerfile_path.parent()` by `ReplConfig::new`.
     /// If a different context directory is required, use `ReplConfig::with_context`.
@@ -25,6 +40,11 @@ pub struct ReplConfig {
     /// `None` means "use the final stage" (default behavior).
     /// `:reload` uses this to re-apply the same selection after re-running the engine.
     pub selected_stage: Option<String>,
+    /// Present when the session was started in Compose mode (`--compose`).
+    ///
+    /// `None` in single-Dockerfile mode. When `Some`, REPL commands such as
+    /// `:services`, `:mounts`, and `:depends` are available.
+    pub compose_context: Option<ComposeContext>,
 }
 
 impl ReplConfig {
@@ -44,6 +64,7 @@ impl ReplConfig {
             dockerfile_path,
             context_dir,
             selected_stage: None,
+            compose_context: None,
         }
     }
 
@@ -57,6 +78,7 @@ impl ReplConfig {
             dockerfile_path,
             context_dir,
             selected_stage: None,
+            compose_context: None,
         }
     }
 
@@ -68,13 +90,72 @@ impl ReplConfig {
         self.selected_stage = stage;
         self
     }
+
+    /// Attach a `ComposeContext` to this config.
+    ///
+    /// Called from `main` when `--compose` is set. Makes the parsed Compose file
+    /// and selected service name available to the REPL for Compose-aware commands.
+    pub fn with_compose_context(mut self, ctx: Option<ComposeContext>) -> Self {
+        self.compose_context = ctx;
+        self
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::model::compose::ComposeFile;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
+
+    fn empty_compose_file() -> ComposeFile {
+        ComposeFile {
+            services: BTreeMap::new(),
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- ComposeContext is stored and retrieved via builder ---
+
+    #[test]
+    fn repl_config_compose_context_defaults_to_none() {
+        let config = ReplConfig::new(PathBuf::from("/project/Dockerfile"));
+        assert!(config.compose_context.is_none());
+    }
+
+    #[test]
+    fn repl_config_with_context_compose_context_defaults_to_none() {
+        let config = ReplConfig::with_context(
+            PathBuf::from("/project/docker/Dockerfile"),
+            PathBuf::from("/project"),
+        );
+        assert!(config.compose_context.is_none());
+    }
+
+    #[test]
+    fn repl_config_with_compose_context_stores_value() {
+        let ctx = ComposeContext {
+            compose_file: empty_compose_file(),
+            selected_service: "api".to_string(),
+        };
+        let config =
+            ReplConfig::new(PathBuf::from("/project/compose.yaml")).with_compose_context(Some(ctx));
+        let stored = config.compose_context.expect("should be Some");
+        assert_eq!(stored.selected_service, "api");
+    }
+
+    #[test]
+    fn repl_config_with_compose_context_none_clears() {
+        let ctx = ComposeContext {
+            compose_file: empty_compose_file(),
+            selected_service: "api".to_string(),
+        };
+        let config = ReplConfig::new(PathBuf::from("/project/compose.yaml"))
+            .with_compose_context(Some(ctx))
+            .with_compose_context(None);
+        assert!(config.compose_context.is_none());
+    }
 
     // --- ReplConfig::new derives context_dir from parent ---
 

--- a/src/repl/custom/depends.rs
+++ b/src/repl/custom/depends.rs
@@ -7,8 +7,21 @@
 //     └─ db
 //     └─ redis
 //
-// Cycles are detected via a visited set. When a cycle is found, traversal
-// stops at that edge and a `[cycle detected]` marker is appended inline.
+// # Cycle detection
+// Cycles are detected via an `on_stack` visited set. When a node that is
+// already on the current DFS path is visited again, traversal stops at that
+// edge and a `[cycle detected]` marker is appended inline.
+//
+// # Diamond / shared dependency deduplication
+// A second `fully_visited` set tracks nodes whose subtrees have been fully
+// expanded in any branch. When a node is in `fully_visited`, the tree prints
+// `[shared, see above]` instead of re-expanding the subtree. This prevents
+// duplicate output for diamond dependency patterns.
+//
+// # Validation
+// If `ctx.selected_service` is not found in the service map, a warning line
+// is printed and the command returns without a tree — avoiding output that
+// looks like a valid (but wrong) leaf-service view.
 //
 // In single-Dockerfile mode (no ComposeContext), prints a clear usage hint.
 
@@ -47,18 +60,42 @@ pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<
     let root = &ctx.selected_service;
     let services = &ctx.compose_file.services;
 
-    // Print root service.
+    // #63: Validate that the selected service exists in the map. If not,
+    // output a clear warning rather than silently showing empty tree output
+    // that looks identical to a valid leaf service.
     let safe_root = sanitize_for_terminal(root);
+    if !services.contains_key(root.as_str()) {
+        writeln!(
+            writer,
+            "warning: service '{safe_root}' not found in compose file"
+        )
+        .map_err(io_err)?;
+        return Ok(());
+    }
+
+    // Print root service.
     writeln!(writer, "{safe_root}").map_err(io_err)?;
 
-    // DFS traversal with a visited set to detect cycles.
-    let mut visited: HashSet<String> = HashSet::new();
-    visited.insert(root.clone());
+    // #64: Two-set DFS:
+    // - `on_stack`: nodes on the current path from root → cycle detection.
+    // - `fully_visited`: nodes whose subtrees have been fully expanded in any
+    //   prior branch → print `[shared, see above]` instead of re-expanding.
+    let mut on_stack: HashSet<String> = HashSet::new();
+    let mut fully_visited: HashSet<String> = HashSet::new();
+    on_stack.insert(root.clone());
 
     // Collect immediate dependencies of root, in original order.
-    if let Some(svc) = services.get(root) {
+    if let Some(svc) = services.get(root.as_str()) {
         for dep in &svc.depends_on {
-            print_dep_tree(dep, services, &mut visited, 1, writer, &io_err)?;
+            print_dep_tree(
+                dep,
+                services,
+                &mut on_stack,
+                &mut fully_visited,
+                1,
+                writer,
+                &io_err,
+            )?;
         }
     }
 
@@ -68,11 +105,15 @@ pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<
 /// Recursively print one level of the dependency tree.
 ///
 /// `depth` controls the indentation level (1 = first level of children).
-/// `visited` carries the path from the root to detect cycles.
+/// `on_stack` contains nodes on the current DFS path (cycle detection).
+/// `fully_visited` contains nodes whose subtrees were already fully printed
+/// in a prior branch; these are shown as `[shared, see above]` instead of
+/// being re-expanded.
 fn print_dep_tree(
     name: &str,
     services: &std::collections::BTreeMap<String, crate::model::compose::Service>,
-    visited: &mut HashSet<String>,
+    on_stack: &mut HashSet<String>,
+    fully_visited: &mut HashSet<String>,
     depth: usize,
     writer: &mut impl Write,
     io_err: &impl Fn(std::io::Error) -> ReplError,
@@ -80,26 +121,41 @@ fn print_dep_tree(
     let indent = "  ".repeat(depth);
     let safe_name = sanitize_for_terminal(name);
 
-    if visited.contains(name) {
-        // Cycle detected — print the name with a marker, do not recurse.
+    if on_stack.contains(name) {
+        // Cycle detected — this node is already on the current path.
         writeln!(writer, "{indent}└─ {safe_name}  [cycle detected]").map_err(io_err)?;
+        return Ok(());
+    }
+
+    if fully_visited.contains(name) {
+        // Already fully expanded in a prior branch — avoid duplicate subtrees.
+        writeln!(writer, "{indent}└─ {safe_name}  [shared, see above]").map_err(io_err)?;
         return Ok(());
     }
 
     writeln!(writer, "{indent}└─ {safe_name}").map_err(io_err)?;
 
-    // Mark as visited for the sub-tree.
-    visited.insert(name.to_string());
+    // Mark on the current path and recurse into dependencies.
+    on_stack.insert(name.to_string());
 
-    // Recurse into this service's own dependencies.
     if let Some(svc) = services.get(name) {
         for dep in &svc.depends_on {
-            print_dep_tree(dep, services, visited, depth + 1, writer, io_err)?;
+            print_dep_tree(
+                dep,
+                services,
+                on_stack,
+                fully_visited,
+                depth + 1,
+                writer,
+                io_err,
+            )?;
         }
     }
 
-    // Unmark when returning (allow the same service to appear in separate branches).
-    visited.remove(name);
+    // Remove from current path on backtrack, then mark as fully visited so
+    // future branches that reach this node show `[shared, see above]`.
+    on_stack.remove(name);
+    fully_visited.insert(name.to_string());
 
     Ok(())
 }
@@ -280,8 +336,10 @@ mod tests {
     // --- same service appears in multiple branches (diamond pattern) ---
 
     #[test]
-    fn diamond_dependency_not_false_cycle() {
-        // api → db AND api → cache; both → shared (diamond, not a cycle)
+    fn diamond_dependency_shows_shared_see_above() {
+        // api → db AND api → cache; both → shared (diamond, not a cycle).
+        // With the two-set DFS: shared appears fully under db (whichever comes
+        // first alphabetically), then as `[shared, see above]` under cache.
         let shared = bare_service("shared");
         let db = Service {
             depends_on: vec!["shared".to_string()],
@@ -303,15 +361,46 @@ mod tests {
             selected_service: "api".to_string(),
         };
         let out = run(Some(&ctx));
-        // shared should appear twice (once under db, once under cache) — NOT flagged as cycle
-        let shared_count = out.matches("└─ shared").count();
-        assert_eq!(
-            shared_count, 2,
-            "shared should appear twice in diamond; got:\n{out}"
-        );
+        // No cycle must be reported.
         assert!(
             !out.contains("[cycle detected]"),
             "diamond pattern must not trigger cycle detection; got:\n{out}"
+        );
+        // shared must appear exactly once as a normal entry and once as [shared, see above].
+        let full_count = out.matches("└─ shared").count();
+        let shared_above = out.contains("[shared, see above]");
+        assert_eq!(
+            full_count, 2,
+            "shared must appear twice total (once full, once marker); got:\n{out}"
+        );
+        assert!(
+            shared_above,
+            "second occurrence of shared must show '[shared, see above]'; got:\n{out}"
+        );
+    }
+
+    // --- #63: selected_service not in map ---
+
+    #[test]
+    fn selected_service_not_in_map_shows_warning() {
+        let db = bare_service("db");
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![db]),
+            selected_service: "typo_service".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.contains("warning:"),
+            "must show a warning when selected service is not found; got: {out}"
+        );
+        assert!(
+            out.contains("typo_service"),
+            "warning must mention the missing service name; got: {out}"
+        );
+        // Must NOT show a bare root line that looks like a valid leaf.
+        assert!(
+            !out.trim().eq("typo_service"),
+            "must not output bare name as if it were a valid leaf; got: {out}"
         );
     }
 

--- a/src/repl/custom/depends.rs
+++ b/src/repl/custom/depends.rs
@@ -1,0 +1,341 @@
+// `:depends` command — render the dependency tree for the selected service.
+//
+// In Compose mode, performs a depth-first traversal of `depends_on` starting
+// from the selected service and prints an indented tree:
+//
+//   api
+//     └─ db
+//     └─ redis
+//
+// Cycles are detected via a visited set. When a cycle is found, traversal
+// stops at that edge and a `[cycle detected]` marker is appended inline.
+//
+// In single-Dockerfile mode (no ComposeContext), prints a clear usage hint.
+
+use std::collections::HashSet;
+use std::io::Write;
+
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::config::ComposeContext;
+use crate::repl::error::ReplError;
+
+/// Guard message printed when `:depends` is invoked outside Compose mode.
+const GUARD_MSG: &str = "\
+:depends is only available in compose mode
+  Usage: demu --compose -f compose.yaml --service <name>
+";
+
+/// Execute the `:depends` command.
+///
+/// When `ctx` is `None` the guard message is printed.
+/// When `ctx` is `Some`, a dependency tree is rendered starting from
+/// `ctx.selected_service`.
+pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: ":depends".to_string(),
+        message: e.to_string(),
+    };
+
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            write!(writer, "{GUARD_MSG}").map_err(io_err)?;
+            return Ok(());
+        }
+    };
+
+    let root = &ctx.selected_service;
+    let services = &ctx.compose_file.services;
+
+    // Print root service.
+    let safe_root = sanitize_for_terminal(root);
+    writeln!(writer, "{safe_root}").map_err(io_err)?;
+
+    // DFS traversal with a visited set to detect cycles.
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(root.clone());
+
+    // Collect immediate dependencies of root, in original order.
+    if let Some(svc) = services.get(root) {
+        for dep in &svc.depends_on {
+            print_dep_tree(dep, services, &mut visited, 1, writer, &io_err)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Recursively print one level of the dependency tree.
+///
+/// `depth` controls the indentation level (1 = first level of children).
+/// `visited` carries the path from the root to detect cycles.
+fn print_dep_tree(
+    name: &str,
+    services: &std::collections::BTreeMap<String, crate::model::compose::Service>,
+    visited: &mut HashSet<String>,
+    depth: usize,
+    writer: &mut impl Write,
+    io_err: &impl Fn(std::io::Error) -> ReplError,
+) -> Result<(), ReplError> {
+    let indent = "  ".repeat(depth);
+    let safe_name = sanitize_for_terminal(name);
+
+    if visited.contains(name) {
+        // Cycle detected — print the name with a marker, do not recurse.
+        writeln!(writer, "{indent}└─ {safe_name}  [cycle detected]").map_err(io_err)?;
+        return Ok(());
+    }
+
+    writeln!(writer, "{indent}└─ {safe_name}").map_err(io_err)?;
+
+    // Mark as visited for the sub-tree.
+    visited.insert(name.to_string());
+
+    // Recurse into this service's own dependencies.
+    if let Some(svc) = services.get(name) {
+        for dep in &svc.depends_on {
+            print_dep_tree(dep, services, visited, depth + 1, writer, io_err)?;
+        }
+    }
+
+    // Unmark when returning (allow the same service to appear in separate branches).
+    visited.remove(name);
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::compose::{ComposeFile, Service, VolumeDefinition};
+    use crate::repl::config::ComposeContext;
+    use std::collections::BTreeMap;
+
+    fn run(ctx: Option<&ComposeContext>) -> String {
+        let mut buf = Vec::new();
+        execute(ctx, &mut buf).expect("depends should not fail");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    fn bare_service(name: &str) -> Service {
+        Service {
+            name: name.to_string(),
+            build: None,
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        }
+    }
+
+    fn compose_with_services(services: Vec<Service>) -> ComposeFile {
+        let mut map = BTreeMap::new();
+        for svc in services {
+            map.insert(svc.name.clone(), svc);
+        }
+        ComposeFile {
+            services: map,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- guard mode ---
+
+    #[test]
+    fn no_context_prints_guard_message() {
+        let out = run(None);
+        assert!(
+            out.contains(":depends is only available in compose mode"),
+            "guard message missing; got: {out}"
+        );
+        assert!(
+            out.contains("--compose"),
+            "usage hint must mention --compose; got: {out}"
+        );
+    }
+
+    // --- leaf service (no dependencies) ---
+
+    #[test]
+    fn leaf_service_shows_root_only() {
+        let db = bare_service("db");
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![db]),
+            selected_service: "db".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.trim() == "db",
+            "leaf service should only print its name; got: {out}"
+        );
+    }
+
+    // --- service with one dependency ---
+
+    #[test]
+    fn single_dependency_shows_tree_entry() {
+        let db = bare_service("db");
+        let api = Service {
+            depends_on: vec!["db".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.starts_with("api\n"),
+            "root must be first line; got: {out}"
+        );
+        assert!(
+            out.contains("└─ db"),
+            "dependency must appear as tree entry; got: {out}"
+        );
+    }
+
+    // --- service with two dependencies ---
+
+    #[test]
+    fn two_dependencies_both_appear() {
+        let db = bare_service("db");
+        let redis = bare_service("redis");
+        let api = Service {
+            depends_on: vec!["db".to_string(), "redis".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db, redis]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("└─ db"), "db must appear; got: {out}");
+        assert!(out.contains("└─ redis"), "redis must appear; got: {out}");
+    }
+
+    // --- multi-level tree ---
+
+    #[test]
+    fn multi_level_tree_indented_correctly() {
+        // api → db → cache (3 levels)
+        let cache = bare_service("cache");
+        let db = Service {
+            depends_on: vec!["cache".to_string()],
+            image: Some("postgres".to_string()),
+            ..bare_service("db")
+        };
+        let api = Service {
+            depends_on: vec!["db".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, cache, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.starts_with("api"), "root first; got: {out}");
+        assert!(out.contains("└─ db"), "first level; got: {out}");
+        // cache must appear indented at a deeper level than db
+        let db_pos = out.find("└─ db").expect("db must be present");
+        let cache_pos = out.find("└─ cache").expect("cache must be present");
+        assert!(
+            cache_pos > db_pos,
+            "cache must appear after db; got:\n{out}"
+        );
+    }
+
+    // --- cycle detection ---
+
+    #[test]
+    fn cycle_is_detected_and_marked() {
+        // a → b → a (cycle)
+        let a = Service {
+            depends_on: vec!["b".to_string()],
+            image: Some("img".to_string()),
+            ..bare_service("a")
+        };
+        let b = Service {
+            depends_on: vec!["a".to_string()],
+            image: Some("img".to_string()),
+            ..bare_service("b")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![a, b]),
+            selected_service: "a".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.contains("[cycle detected]"),
+            "cycle must be marked; got: {out}"
+        );
+    }
+
+    // --- same service appears in multiple branches (diamond pattern) ---
+
+    #[test]
+    fn diamond_dependency_not_false_cycle() {
+        // api → db AND api → cache; both → shared (diamond, not a cycle)
+        let shared = bare_service("shared");
+        let db = Service {
+            depends_on: vec!["shared".to_string()],
+            image: Some("postgres".to_string()),
+            ..bare_service("db")
+        };
+        let cache = Service {
+            depends_on: vec!["shared".to_string()],
+            image: Some("redis".to_string()),
+            ..bare_service("cache")
+        };
+        let api = Service {
+            depends_on: vec!["db".to_string(), "cache".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, cache, db, shared]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        // shared should appear twice (once under db, once under cache) — NOT flagged as cycle
+        let shared_count = out.matches("└─ shared").count();
+        assert_eq!(
+            shared_count, 2,
+            "shared should appear twice in diamond; got:\n{out}"
+        );
+        assert!(
+            !out.contains("[cycle detected]"),
+            "diamond pattern must not trigger cycle detection; got:\n{out}"
+        );
+    }
+
+    // --- ANSI sanitization ---
+
+    #[test]
+    fn ansi_escape_in_service_name_is_stripped() {
+        let evil_dep = Service {
+            image: Some("img".to_string()),
+            ..bare_service("dep\x1b[2J")
+        };
+        let api = Service {
+            depends_on: vec!["dep\x1b[2J".to_string()],
+            image: Some("myapp".to_string()),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, evil_dep]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            !out.contains('\x1b'),
+            "ANSI escapes must be stripped; got: {out:?}"
+        );
+    }
+}

--- a/src/repl/custom/depends.rs
+++ b/src/repl/custom/depends.rs
@@ -44,7 +44,7 @@ const GUARD_MSG: &str = "\
 /// When `ctx` is `Some`, a dependency tree is rendered starting from
 /// `ctx.selected_service`.
 pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":depends".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/history.rs
+++ b/src/repl/custom/history.rs
@@ -23,10 +23,10 @@ use crate::repl::error::ReplError;
 /// message `"No history recorded."` is printed instead.
 ///
 /// All output goes to `writer`; I/O errors are mapped to
-/// [`ReplError::InvalidArguments`].
+/// [`ReplError::Io`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a ReplError so callers have a uniform error type.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":history".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/installed.rs
+++ b/src/repl/custom/installed.rs
@@ -36,7 +36,7 @@ const MANAGER_ORDER: &[&str] = &["apt", "pip", "npm", "apk", "go"];
 /// When no packages are recorded at all, prints `"No packages recorded."`.
 ///
 /// All output goes to `writer`; I/O errors are mapped to
-/// [`ReplError::InvalidArguments`].
+/// [`ReplError::Io`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a uniform ReplError.
     let io_err = io_err_mapper(":installed");

--- a/src/repl/custom/layers.rs
+++ b/src/repl/custom/layers.rs
@@ -27,10 +27,10 @@ use crate::repl::error::ReplError;
 /// instead.
 ///
 /// All output goes to `writer`; I/O errors are mapped to
-/// [`ReplError::InvalidArguments`].
+/// [`ReplError::Io`].
 pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
     // Map I/O errors into a ReplError so callers have a uniform error type.
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":layers".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/mod.rs
+++ b/src/repl/custom/mod.rs
@@ -7,9 +7,11 @@
 // `reload` is the only handler here that mutates `PreviewState`; all others
 // are pure read commands.
 
+pub mod depends;
 pub mod explain;
 pub mod history;
 pub mod installed;
 pub mod layers;
 pub mod mounts;
 pub mod reload;
+pub mod services;

--- a/src/repl/custom/mod.rs
+++ b/src/repl/custom/mod.rs
@@ -11,4 +11,5 @@ pub mod explain;
 pub mod history;
 pub mod installed;
 pub mod layers;
+pub mod mounts;
 pub mod reload;

--- a/src/repl/custom/mounts.rs
+++ b/src/repl/custom/mounts.rs
@@ -32,7 +32,7 @@ pub fn execute(
     compose_ctx: Option<&ComposeContext>,
     writer: &mut impl Write,
 ) -> Result<(), ReplError> {
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":mounts".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/custom/mounts.rs
+++ b/src/repl/custom/mounts.rs
@@ -1,0 +1,183 @@
+// `:mounts` command — list all volume mount shadows applied by the Compose engine.
+//
+// In Compose mode, `run_compose` populates `state.mounts` with one `MountInfo`
+// per volume entry declared in the selected service.  This command renders that
+// list in a compact, terminal-friendly format:
+//
+//   Mount shadows (2 total):
+//     /data           bind mount from ./data  [rw]
+//     /root/.npm      named volume: npm-cache  [ro]
+//
+// When no mounts have been recorded (e.g. in plain Dockerfile mode or when the
+// Compose service declares no volumes), a brief sentinel line is printed.
+
+use std::io::Write;
+
+use crate::model::state::PreviewState;
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::error::ReplError;
+
+/// Execute the `:mounts` command.
+///
+/// Writes a formatted list of all volume mount shadows to `writer`.
+/// When `state.mounts` is empty, prints `"No mount shadows recorded."`.
+pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: ":mounts".to_string(),
+        message: e.to_string(),
+    };
+
+    if state.mounts.is_empty() {
+        writeln!(writer, "No mount shadows recorded.").map_err(io_err)?;
+        return Ok(());
+    }
+
+    writeln!(writer, "Mount shadows ({} total):", state.mounts.len()).map_err(io_err)?;
+
+    for mount in &state.mounts {
+        // Sanitize user-supplied data before writing to the terminal.
+        let safe_path = sanitize_for_terminal(&mount.container_path.display().to_string());
+        let safe_desc = sanitize_for_terminal(&mount.description);
+        let rw_label = if mount.read_only { "ro" } else { "rw" };
+
+        writeln!(writer, "  {safe_path}  {safe_desc}  [{rw_label}]").map_err(io_err)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::provenance::MountInfo;
+    use crate::model::state::PreviewState;
+    use std::path::PathBuf;
+
+    fn run(state: &PreviewState) -> String {
+        let mut buf = Vec::new();
+        execute(state, &mut buf).expect("mounts should not fail");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    // --- empty state ---
+
+    #[test]
+    fn empty_mounts_prints_sentinel() {
+        let state = PreviewState::default();
+        let out = run(&state);
+        assert_eq!(out.trim(), "No mount shadows recorded.", "got: {out}");
+    }
+
+    // --- single bind mount ---
+
+    #[test]
+    fn bind_mount_shows_container_path_and_description() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("/data"),
+            "must show container path; got: {out}"
+        );
+        assert!(
+            out.contains("bind mount from ./data"),
+            "must show description; got: {out}"
+        );
+        assert!(out.contains("[rw]"), "must show rw label; got: {out}");
+    }
+
+    // --- read-only mount ---
+
+    #[test]
+    fn read_only_mount_shows_ro_label() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/config"),
+            read_only: true,
+            description: "named volume: cfg".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("[ro]"),
+            "read-only mount must show [ro]; got: {out}"
+        );
+    }
+
+    // --- named volume ---
+
+    #[test]
+    fn named_volume_shows_volume_name_in_description() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/root/.npm"),
+            read_only: false,
+            description: "named volume: npm-cache".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("named volume: npm-cache"),
+            "must show named volume; got: {out}"
+        );
+    }
+
+    // --- anonymous volume ---
+
+    #[test]
+    fn anonymous_volume_shows_description() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/tmp/scratch"),
+            read_only: false,
+            description: "anonymous volume".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("anonymous volume"),
+            "must show anonymous volume; got: {out}"
+        );
+    }
+
+    // --- total count in header ---
+
+    #[test]
+    fn header_shows_correct_count() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from ./data".to_string(),
+        });
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/cache"),
+            read_only: false,
+            description: "named volume: cache".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            out.contains("Mount shadows (2 total):"),
+            "header must show count; got: {out}"
+        );
+    }
+
+    // --- ANSI sanitization ---
+
+    #[test]
+    fn ansi_escape_in_description_is_stripped() {
+        let mut state = PreviewState::default();
+        state.mounts.push(MountInfo {
+            container_path: PathBuf::from("/data"),
+            read_only: false,
+            description: "bind mount from \x1b[2J./data".to_string(),
+        });
+        let out = run(&state);
+        assert!(
+            !out.contains('\x1b'),
+            "ANSI escapes must be stripped; got: {out:?}"
+        );
+    }
+}

--- a/src/repl/custom/mounts.rs
+++ b/src/repl/custom/mounts.rs
@@ -8,24 +8,39 @@
 //     /data           bind mount from ./data  [rw]
 //     /root/.npm      named volume: npm-cache  [ro]
 //
-// When no mounts have been recorded (e.g. in plain Dockerfile mode or when the
-// Compose service declares no volumes), a brief sentinel line is printed.
+// In single-Dockerfile mode (no ComposeContext), prints a clear usage hint.
 
 use std::io::Write;
 
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::config::ComposeContext;
 use crate::repl::error::ReplError;
+
+/// Guard message printed when `:mounts` is invoked outside Compose mode.
+const GUARD_MSG: &str = "\
+:mounts is only available in compose mode
+  Usage: demu --compose -f compose.yaml --service <name>
+";
 
 /// Execute the `:mounts` command.
 ///
-/// Writes a formatted list of all volume mount shadows to `writer`.
-/// When `state.mounts` is empty, prints `"No mount shadows recorded."`.
-pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), ReplError> {
+/// When `compose_ctx` is `None` the guard message is printed.
+/// Otherwise, writes a formatted list of all volume mount shadows to `writer`.
+pub fn execute(
+    state: &PreviewState,
+    compose_ctx: Option<&ComposeContext>,
+    writer: &mut impl Write,
+) -> Result<(), ReplError> {
     let io_err = |e: std::io::Error| ReplError::InvalidArguments {
         command: ":mounts".to_string(),
         message: e.to_string(),
     };
+
+    if compose_ctx.is_none() {
+        write!(writer, "{GUARD_MSG}").map_err(io_err)?;
+        return Ok(());
+    }
 
     if state.mounts.is_empty() {
         writeln!(writer, "No mount shadows recorded.").map_err(io_err)?;
@@ -50,22 +65,48 @@ pub fn execute(state: &PreviewState, writer: &mut impl Write) -> Result<(), Repl
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::model::compose::ComposeFile;
     use crate::model::provenance::MountInfo;
     use crate::model::state::PreviewState;
+    use crate::repl::config::ComposeContext;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    fn run(state: &PreviewState) -> String {
+    fn dummy_ctx() -> ComposeContext {
+        ComposeContext {
+            compose_file: ComposeFile {
+                services: BTreeMap::new(),
+                volumes: BTreeMap::new(),
+            },
+            selected_service: "svc".to_string(),
+        }
+    }
+
+    fn run(state: &PreviewState, ctx: Option<&ComposeContext>) -> String {
         let mut buf = Vec::new();
-        execute(state, &mut buf).expect("mounts should not fail");
+        execute(state, ctx, &mut buf).expect("mounts should not fail");
         String::from_utf8(buf).expect("utf-8")
+    }
+
+    // --- guard mode ---
+
+    #[test]
+    fn no_context_prints_guard_message() {
+        let state = PreviewState::default();
+        let out = run(&state, None);
+        assert!(
+            out.contains(":mounts is only available in compose mode"),
+            "guard message missing; got: {out}"
+        );
     }
 
     // --- empty state ---
 
     #[test]
     fn empty_mounts_prints_sentinel() {
+        let ctx = dummy_ctx();
         let state = PreviewState::default();
-        let out = run(&state);
+        let out = run(&state, Some(&ctx));
         assert_eq!(out.trim(), "No mount shadows recorded.", "got: {out}");
     }
 
@@ -79,7 +120,8 @@ mod tests {
             read_only: false,
             description: "bind mount from ./data".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("/data"),
             "must show container path; got: {out}"
@@ -101,7 +143,8 @@ mod tests {
             read_only: true,
             description: "named volume: cfg".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("[ro]"),
             "read-only mount must show [ro]; got: {out}"
@@ -118,7 +161,8 @@ mod tests {
             read_only: false,
             description: "named volume: npm-cache".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("named volume: npm-cache"),
             "must show named volume; got: {out}"
@@ -135,7 +179,8 @@ mod tests {
             read_only: false,
             description: "anonymous volume".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("anonymous volume"),
             "must show anonymous volume; got: {out}"
@@ -157,7 +202,8 @@ mod tests {
             read_only: false,
             description: "named volume: cache".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             out.contains("Mount shadows (2 total):"),
             "header must show count; got: {out}"
@@ -174,7 +220,8 @@ mod tests {
             read_only: false,
             description: "bind mount from \x1b[2J./data".to_string(),
         });
-        let out = run(&state);
+        let ctx = dummy_ctx();
+        let out = run(&state, Some(&ctx));
         assert!(
             !out.contains('\x1b'),
             "ANSI escapes must be stripped; got: {out:?}"

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use crate::engine;
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
-use crate::parser::dockerfile::parse_dockerfile;
+use crate::parser::{compose::parse_compose, dockerfile::parse_dockerfile};
 use crate::repl::config::ReplConfig;
 use crate::repl::error::{io_err_mapper, ReplError};
 
@@ -34,6 +34,12 @@ pub fn execute(
     writer: &mut impl Write,
     err_writer: &mut impl Write,
 ) -> Result<(), ReplError> {
+    // Compose mode: re-parse the compose file and re-run the compose engine.
+    // The Dockerfile pipeline is the `else` branch below.
+    if config.compose_context.is_some() {
+        return execute_compose(state, config, writer, err_writer);
+    }
+
     // Step 1: Read the Dockerfile from disk.
     // Sanitize the path before embedding it in terminal output — the path
     // comes from the CLI argument and could theoretically contain control bytes.
@@ -119,11 +125,87 @@ pub fn execute(
     Ok(())
 }
 
+/// Reload for Compose mode.
+///
+/// Re-reads the compose file, re-parses it, and re-runs the compose engine
+/// for the previously selected service. On any error, the old state is
+/// preserved and the error is written to `err_writer`.
+fn execute_compose(
+    state: &mut PreviewState,
+    config: &ReplConfig,
+    writer: &mut impl Write,
+    err_writer: &mut impl Write,
+) -> Result<(), ReplError> {
+    // The compose context must be present when this function is called.
+    // The caller (`execute`) routes here only when `compose_context.is_some()`.
+    // Return early rather than panic to maintain the REPL's non-crashing guarantee.
+    let ctx = match config.compose_context.as_ref() {
+        Some(ctx) => ctx,
+        None => return Ok(()),
+    };
+
+    // Step 1: Re-read the compose file.
+    let content = match std::fs::read_to_string(&config.dockerfile_path) {
+        Ok(c) => c,
+        Err(e) => {
+            let safe_path = sanitize_for_terminal(&config.dockerfile_path.display().to_string());
+            writeln!(
+                err_writer,
+                "demu: cannot read compose file '{}': {e}",
+                safe_path
+            )
+            .map_err(io_err_mapper(":reload"))?;
+            return Ok(());
+        }
+    };
+
+    // Step 2: Re-parse the compose file.
+    let compose_file = match parse_compose(&content) {
+        Ok(cf) => cf,
+        Err(e) => {
+            let safe_msg = sanitize_for_terminal(&e.to_string());
+            writeln!(err_writer, "demu: compose parse error: {safe_msg}")
+                .map_err(io_err_mapper(":reload"))?;
+            return Ok(());
+        }
+    };
+
+    // Step 3: Re-run the compose engine.
+    let compose_output =
+        match engine::run_compose(&compose_file, &ctx.selected_service, &config.context_dir) {
+            Ok(out) => out,
+            Err(e) => {
+                let safe_msg = sanitize_for_terminal(&e.to_string());
+                writeln!(err_writer, "demu: compose engine error: {safe_msg}")
+                    .map_err(io_err_mapper(":reload"))?;
+                return Ok(());
+            }
+        };
+
+    // Step 4: Emit warnings, replace state, confirm.
+    let new_state = compose_output.state;
+    for w in &new_state.warnings {
+        writeln!(
+            err_writer,
+            "warning: {}",
+            sanitize_for_terminal(&w.to_string())
+        )
+        .map_err(io_err_mapper(":reload"))?;
+    }
+
+    let n = new_state.history.len();
+    *state = new_state;
+    writeln!(writer, "Reloaded. {n} instructions processed.").map_err(io_err_mapper(":reload"))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::repl::config::ReplConfig;
+    use crate::model::compose::ComposeFile;
+    use crate::repl::config::{ComposeContext, ReplConfig};
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
@@ -507,6 +589,141 @@ mod tests {
         assert!(
             !state.env.contains_key("CTX_FINAL"),
             "state must NOT be final stage"
+        );
+    }
+
+    // ── Compose mode reload tests ─────────────────────────────────────────────
+
+    /// Build a minimal `ComposeFile` with a single build service.
+    fn make_compose_file_with_service(service_name: &str) -> ComposeFile {
+        use crate::model::compose::{BuildConfig, Service, VolumeDefinition};
+        use std::collections::BTreeMap;
+        let service = Service {
+            name: service_name.to_string(),
+            build: Some(BuildConfig {
+                context: std::path::PathBuf::from("."),
+                dockerfile: std::path::PathBuf::from("Dockerfile"),
+            }),
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        };
+        let mut services = BTreeMap::new();
+        services.insert(service_name.to_string(), service);
+        ComposeFile {
+            services,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- reload_compose_mode_replaces_state ---
+    //
+    // Compose mode reload: after a reload, the state reflects the env vars
+    // set in the Dockerfile referenced by the compose file.
+
+    #[test]
+    fn reload_compose_mode_replaces_state() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(
+            dir.path().join("Dockerfile"),
+            b"FROM scratch\nENV RELOAD_VAR=ok\n",
+        )
+        .expect("write Dockerfile");
+
+        let compose_yaml = format!(
+            "services:\n  api:\n    build:\n      context: .\n      dockerfile: Dockerfile\n    environment:\n      - COMPOSE_VAR=hello\n"
+        );
+        let compose_path = dir.path().join("compose.yaml");
+        std::fs::write(&compose_path, compose_yaml.as_bytes()).expect("write compose.yaml");
+
+        let ctx = ComposeContext {
+            compose_file: make_compose_file_with_service("api"),
+            selected_service: "api".to_string(),
+        };
+        let config = ReplConfig::with_context(compose_path, dir.path().to_path_buf())
+            .with_compose_context(Some(ctx));
+        let mut state = PreviewState::default();
+
+        let (result, out, _err) = run_reload(&mut state, &config);
+        assert!(result.is_ok(), "execute must return Ok; got: {result:?}");
+        assert!(
+            out.contains("Reloaded."),
+            "stdout must contain 'Reloaded.'; got: {out}"
+        );
+        assert_eq!(
+            state.env.get("COMPOSE_VAR").map(String::as_str),
+            Some("hello"),
+            "state must contain COMPOSE_VAR=hello from compose environment"
+        );
+    }
+
+    // --- reload_compose_mode_parse_error_keeps_old_state ---
+    //
+    // If the compose file is invalid YAML on reload, old state is preserved.
+
+    #[test]
+    fn reload_compose_mode_parse_error_keeps_old_state() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let compose_path = dir.path().join("compose.yaml");
+        std::fs::write(&compose_path, b"{ not: valid: yaml: [\n").expect("write bad yaml");
+
+        let ctx = ComposeContext {
+            compose_file: make_compose_file_with_service("api"),
+            selected_service: "api".to_string(),
+        };
+        let config = ReplConfig::with_context(compose_path, dir.path().to_path_buf())
+            .with_compose_context(Some(ctx));
+        let mut state = PreviewState::default();
+        state.cwd = PathBuf::from("/original");
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(
+            result.is_ok(),
+            "execute must return Ok on parse error; got: {result:?}"
+        );
+        assert_eq!(
+            state.cwd,
+            PathBuf::from("/original"),
+            "state must be preserved on parse error"
+        );
+        assert!(
+            err.contains("parse error") || err.contains("compose"),
+            "stderr must mention compose parse error; got: {err}"
+        );
+    }
+
+    // --- reload_compose_mode_emits_warnings ---
+    //
+    // An image-only service emits ImageOnlyService warning on reload.
+
+    #[test]
+    fn reload_compose_mode_emits_warnings() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let compose_path = dir.path().join("compose.yaml");
+        let compose_yaml = "services:\n  db:\n    image: postgres:15\n";
+        std::fs::write(&compose_path, compose_yaml.as_bytes()).expect("write compose");
+
+        let ctx = ComposeContext {
+            compose_file: make_compose_file_with_service("db"),
+            selected_service: "db".to_string(),
+        };
+        let config = ReplConfig::with_context(compose_path, dir.path().to_path_buf())
+            .with_compose_context(Some(ctx));
+        let mut state = PreviewState::default();
+
+        let (result, _out, err) = run_reload(&mut state, &config);
+        assert!(result.is_ok());
+        assert!(
+            err.contains("warning:"),
+            "stderr must contain 'warning:' for ImageOnlyService; got: {err}"
+        );
+        assert!(
+            err.contains("filesystem is empty") || err.contains("postgres"),
+            "warning must mention the image or empty filesystem; got: {err}"
         );
     }
 }

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -5,7 +5,7 @@
 // - File read errors   → write message to err_writer, preserve old state, return Ok(())
 // - Parse errors       → write message to err_writer, preserve old state, return Ok(())
 // - Engine errors      → write message to err_writer, preserve old state, return Ok(())
-// - I/O write errors   → return Err(ReplError::InvalidArguments)
+// - I/O write errors   → return Err(ReplError::Io)
 //
 // On success, warnings from the new state are emitted to `err_writer` before
 // the confirmation message is written to `writer`.

--- a/src/repl/custom/reload.rs
+++ b/src/repl/custom/reload.rs
@@ -722,8 +722,8 @@ mod tests {
             "stderr must contain 'warning:' for ImageOnlyService; got: {err}"
         );
         assert!(
-            err.contains("filesystem is empty") || err.contains("postgres"),
-            "warning must mention the image or empty filesystem; got: {err}"
+            err.contains("filesystem is empty"),
+            "ImageOnlyService warning must say 'filesystem is empty'; got: {err}"
         );
     }
 }

--- a/src/repl/custom/services.rs
+++ b/src/repl/custom/services.rs
@@ -49,6 +49,18 @@ pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<
     let services = &ctx.compose_file.services;
     let selected = &ctx.selected_service;
 
+    // #63: Warn if the selected service is not present in the service map.
+    // Without this check, `:services` would silently omit the `*` marker with
+    // no indication to the user that the selected service is unrecognized.
+    if !services.contains_key(selected.as_str()) {
+        let safe_selected = sanitize_for_terminal(selected);
+        writeln!(
+            writer,
+            "warning: selected service '{safe_selected}' not found in compose file"
+        )
+        .map_err(io_err)?;
+    }
+
     // Determine column width from the longest service name (min 8 chars).
     let name_width = services.keys().map(|k| k.len()).max().unwrap_or(0).max(8);
 
@@ -269,6 +281,34 @@ mod tests {
         assert!(
             out.contains("Services (2 total):"),
             "header missing; got: {out}"
+        );
+    }
+
+    // --- #63: selected service not in map emits warning ---
+
+    #[test]
+    fn selected_service_not_in_map_shows_warning() {
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![db]),
+            selected_service: "nonexistent".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.contains("warning:"),
+            "must show warning when selected service is missing; got: {out}"
+        );
+        assert!(
+            out.contains("nonexistent"),
+            "warning must mention the missing service name; got: {out}"
+        );
+        // The service table must still be printed.
+        assert!(
+            out.contains("Services (1 total):"),
+            "table header must still appear; got: {out}"
         );
     }
 

--- a/src/repl/custom/services.rs
+++ b/src/repl/custom/services.rs
@@ -1,0 +1,293 @@
+// `:services` command — list all services in the Compose file.
+//
+// In Compose mode, shows a table of all services with their type (build vs
+// image) and their `depends_on` list. The currently selected service is
+// prefixed with `*`.
+//
+// In single-Dockerfile mode (no ComposeContext), prints a clear usage hint
+// so the user knows how to invoke Compose mode.
+//
+// Example output (Compose mode with 3 services, "api" selected):
+//
+//   Services (3 total):
+//   * api     build: Dockerfile   depends: db, redis
+//     db      image: postgres:15
+//     redis   image: redis:7
+//
+// Column widths are derived from the longest name to keep columns aligned.
+
+use std::io::Write;
+
+use crate::output::sanitize::sanitize_for_terminal;
+use crate::repl::config::ComposeContext;
+use crate::repl::error::ReplError;
+
+/// Guard message printed when `:services` is invoked outside Compose mode.
+const GUARD_MSG: &str = "\
+:services is only available in compose mode
+  Usage: demu --compose -f compose.yaml --service <name>
+";
+
+/// Execute the `:services` command.
+///
+/// When `ctx` is `None` the guard message is printed.
+/// When `ctx` is `Some`, a formatted service table is printed.
+pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
+    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+        command: ":services".to_string(),
+        message: e.to_string(),
+    };
+
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            write!(writer, "{GUARD_MSG}").map_err(io_err)?;
+            return Ok(());
+        }
+    };
+
+    let services = &ctx.compose_file.services;
+    let selected = &ctx.selected_service;
+
+    // Determine column width from the longest service name (min 8 chars).
+    let name_width = services.keys().map(|k| k.len()).max().unwrap_or(0).max(8);
+
+    writeln!(writer, "Services ({} total):", services.len()).map_err(io_err)?;
+
+    // BTreeMap iterates in sorted order, which keeps output deterministic.
+    for (name, svc) in services {
+        let prefix = if name == selected { '*' } else { ' ' };
+
+        // Build type description: "build: <dockerfile>" or "image: <image>".
+        let type_str = match (&svc.build, &svc.image) {
+            (Some(build), _) => {
+                let df = sanitize_for_terminal(&build.dockerfile.display().to_string());
+                format!("build: {df}")
+            }
+            (None, Some(image)) => {
+                let safe = sanitize_for_terminal(image);
+                format!("image: {safe}")
+            }
+            (None, None) => "image: <unknown>".to_string(),
+        };
+
+        // Build depends_on string: "depends: a, b" or empty.
+        let depends_str = if svc.depends_on.is_empty() {
+            String::new()
+        } else {
+            let names: Vec<String> = svc
+                .depends_on
+                .iter()
+                .map(|d| sanitize_for_terminal(d))
+                .collect();
+            format!("  depends: {}", names.join(", "))
+        };
+
+        let safe_name = sanitize_for_terminal(name);
+        writeln!(
+            writer,
+            "{prefix} {safe_name:<name_width$}  {type_str}{depends_str}"
+        )
+        .map_err(io_err)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::compose::{BuildConfig, ComposeFile, Service, VolumeDefinition};
+    use crate::repl::config::ComposeContext;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn run(ctx: Option<&ComposeContext>) -> String {
+        let mut buf = Vec::new();
+        execute(ctx, &mut buf).expect("services should not fail");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    fn bare_service(name: &str) -> Service {
+        Service {
+            name: name.to_string(),
+            build: None,
+            image: None,
+            environment: vec![],
+            env_file: vec![],
+            volumes: vec![],
+            working_dir: None,
+            depends_on: vec![],
+            ports: vec![],
+        }
+    }
+
+    fn compose_with_services(services: Vec<Service>) -> ComposeFile {
+        let mut map = BTreeMap::new();
+        for svc in services {
+            map.insert(svc.name.clone(), svc);
+        }
+        ComposeFile {
+            services: map,
+            volumes: BTreeMap::new(),
+        }
+    }
+
+    // --- guard mode ---
+
+    #[test]
+    fn no_context_prints_guard_message() {
+        let out = run(None);
+        assert!(
+            out.contains(":services is only available in compose mode"),
+            "guard message missing; got: {out}"
+        );
+        assert!(
+            out.contains("--compose"),
+            "usage hint must mention --compose; got: {out}"
+        );
+    }
+
+    // --- service type: image ---
+
+    #[test]
+    fn image_only_service_shows_image_label() {
+        let svc = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![svc]),
+            selected_service: "db".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("image: postgres:15"), "got: {out}");
+    }
+
+    // --- service type: build ---
+
+    #[test]
+    fn build_service_shows_dockerfile_name() {
+        let svc = Service {
+            build: Some(BuildConfig {
+                context: PathBuf::from("."),
+                dockerfile: PathBuf::from("Dockerfile"),
+            }),
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![svc]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("build: Dockerfile"), "got: {out}");
+    }
+
+    // --- selected service is marked with * ---
+
+    #[test]
+    fn selected_service_is_marked_with_asterisk() {
+        let api = Service {
+            image: Some("nginx".to_string()),
+            ..bare_service("api")
+        };
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        // "* api" must appear in the output.
+        assert!(
+            out.contains("* api"),
+            "selected service must have * prefix; got:\n{out}"
+        );
+        // "  db" (with space prefix) must appear.
+        assert!(
+            out.contains("  db"),
+            "non-selected service must have space prefix; got:\n{out}"
+        );
+    }
+
+    // --- depends_on is listed ---
+
+    #[test]
+    fn depends_on_appears_in_output() {
+        let api = Service {
+            image: Some("myapp".to_string()),
+            depends_on: vec!["db".to_string(), "redis".to_string()],
+            ..bare_service("api")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(out.contains("depends: db, redis"), "got: {out}");
+    }
+
+    // --- service with no depends_on shows no depends label ---
+
+    #[test]
+    fn no_depends_on_shows_no_depends_label() {
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![db]),
+            selected_service: "db".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            !out.contains("depends:"),
+            "no depends_on must not show label; got:\n{out}"
+        );
+    }
+
+    // --- header shows total count ---
+
+    #[test]
+    fn header_shows_service_count() {
+        let api = Service {
+            image: Some("nginx".to_string()),
+            ..bare_service("api")
+        };
+        let db = Service {
+            image: Some("postgres:15".to_string()),
+            ..bare_service("db")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![api, db]),
+            selected_service: "api".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            out.contains("Services (2 total):"),
+            "header missing; got: {out}"
+        );
+    }
+
+    // --- ANSI sanitization ---
+
+    #[test]
+    fn ansi_escape_in_service_name_is_stripped() {
+        let evil = Service {
+            image: Some("postgres".to_string()),
+            ..bare_service("db\x1b[2J")
+        };
+        let ctx = ComposeContext {
+            compose_file: compose_with_services(vec![evil]),
+            selected_service: "db\x1b[2J".to_string(),
+        };
+        let out = run(Some(&ctx));
+        assert!(
+            !out.contains('\x1b'),
+            "ANSI escapes must be stripped; got: {out:?}"
+        );
+    }
+}

--- a/src/repl/custom/services.rs
+++ b/src/repl/custom/services.rs
@@ -33,7 +33,7 @@ const GUARD_MSG: &str = "\
 /// When `ctx` is `None` the guard message is printed.
 /// When `ctx` is `Some`, a formatted service table is printed.
 pub fn execute(ctx: Option<&ComposeContext>, writer: &mut impl Write) -> Result<(), ReplError> {
-    let io_err = |e: std::io::Error| ReplError::InvalidArguments {
+    let io_err = |e: std::io::Error| ReplError::Io {
         command: ":services".to_string(),
         message: e.to_string(),
     };

--- a/src/repl/error.rs
+++ b/src/repl/error.rs
@@ -33,13 +33,20 @@ pub enum ReplError {
     #[error("{command}: {message}")]
     InvalidArguments { command: String, message: String },
 
+    /// A write to the output sink failed (e.g. broken pipe).
+    ///
+    /// Semantically distinct from [`InvalidArguments`]: this variant covers
+    /// I/O failures on the terminal writer, not user input errors.
+    #[error("{command}: output error: {message}")]
+    Io { command: String, message: String },
+
     /// The input did not match any known command.
     #[error("unknown command: '{input}'. Type 'help' for available commands.")]
     UnknownCommand { input: String },
 }
 
 /// Returns a closure that maps a [`std::io::Error`] into
-/// [`ReplError::InvalidArguments`] for the given command name.
+/// [`ReplError::Io`] for the given command name.
 ///
 /// This is a shared helper so that command handlers do not each have to
 /// define the same 3-line inline closure. Use it wherever a `writeln!` or
@@ -56,7 +63,7 @@ pub enum ReplError {
 /// `command` and has no lifetime dependency on the original `&str`.
 pub fn io_err_mapper(command: &str) -> impl Fn(std::io::Error) -> ReplError {
     let command = command.to_owned();
-    move |e| ReplError::InvalidArguments {
+    move |e| ReplError::Io {
         command: command.clone(),
         message: e.to_string(),
     }
@@ -155,20 +162,20 @@ mod tests {
 
     // --- io_err_mapper ---
 
-    /// `io_err_mapper` must produce `ReplError::InvalidArguments` with the
-    /// exact command name and the I/O error message string.
+    /// `io_err_mapper` must produce `ReplError::Io` (not InvalidArguments) with
+    /// the exact command name and the I/O error message string.
     #[test]
-    fn io_err_mapper_produces_invalid_arguments_with_command_name() {
+    fn io_err_mapper_produces_io_error_with_command_name() {
         let mapper = io_err_mapper("test-cmd");
         let raw_err = io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe");
         let err = mapper(raw_err);
         assert_eq!(
             err,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: "test-cmd".to_string(),
                 message: "broken pipe".to_string(),
             },
-            "io_err_mapper must wrap the io::Error into InvalidArguments; got: {err:?}"
+            "io_err_mapper must wrap the io::Error into ReplError::Io; got: {err:?}"
         );
     }
 
@@ -180,14 +187,14 @@ mod tests {
         let e2 = mapper(io::Error::new(io::ErrorKind::Other, "second"));
         assert_eq!(
             e1,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: "multi".to_string(),
                 message: "first".to_string(),
             }
         );
         assert_eq!(
             e2,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: "multi".to_string(),
                 message: "second".to_string(),
             }
@@ -200,11 +207,40 @@ mod tests {
         let err = io_err_mapper(":reload")(io::Error::new(io::ErrorKind::Other, "oops"));
         assert_eq!(
             err,
-            ReplError::InvalidArguments {
+            ReplError::Io {
                 command: ":reload".to_string(),
                 message: "oops".to_string(),
             },
             "colon-prefixed command name must be preserved; got: {err:?}"
         );
+    }
+
+    // --- Io variant ---
+
+    #[test]
+    fn io_variant_display_contains_command_and_message() {
+        let err = ReplError::Io {
+            command: ":mounts".to_string(),
+            message: "broken pipe".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains(":mounts"), "must contain command; got: {msg}");
+        assert!(
+            msg.contains("broken pipe"),
+            "must contain message; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn io_variant_equality() {
+        let a = ReplError::Io {
+            command: "x".to_string(),
+            message: "y".to_string(),
+        };
+        let b = ReplError::Io {
+            command: "x".to_string(),
+            message: "y".to_string(),
+        };
+        assert_eq!(a, b);
     }
 }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -27,7 +27,7 @@ use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
 use crate::repl::commands::{apt, cat, cd, env_cmd, find, help, ls, pip, pwd, which};
 use crate::repl::config::ReplConfig;
-use crate::repl::custom::{explain, history, installed, layers, reload};
+use crate::repl::custom::{explain, history, installed, layers, mounts, reload};
 use crate::repl::error::ReplError;
 use crate::repl::parse::{parse_input, ParsedCommand};
 
@@ -170,6 +170,9 @@ pub fn dispatch(
         }
         ParsedCommand::Explain { path } => {
             explain::execute(state, &path, writer)?;
+        }
+        ParsedCommand::Mounts => {
+            mounts::execute(state, writer)?;
         }
         ParsedCommand::Exit => {
             return Ok(false);

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -26,8 +26,8 @@ use rustyline::DefaultEditor;
 use crate::model::state::PreviewState;
 use crate::output::sanitize::sanitize_for_terminal;
 use crate::repl::commands::{apt, cat, cd, env_cmd, find, help, ls, pip, pwd, which};
-use crate::repl::config::ReplConfig;
-use crate::repl::custom::{explain, history, installed, layers, mounts, reload};
+use crate::repl::config::{ComposeContext, ReplConfig};
+use crate::repl::custom::{depends, explain, history, installed, layers, mounts, reload, services};
 use crate::repl::error::ReplError;
 use crate::repl::parse::{parse_input, ParsedCommand};
 
@@ -76,7 +76,7 @@ pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result
                     continue;
                 }
 
-                match dispatch(state, cmd, &mut out) {
+                match dispatch(state, cmd, config.compose_context.as_ref(), &mut out) {
                     // `exit` / `quit` — terminate the loop cleanly.
                     Ok(false) => break,
                     Ok(true) => {}
@@ -116,6 +116,11 @@ pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result
 /// All handlers write their output to `writer` rather than to stdout, which
 /// makes this function fully testable without capturing stdout.
 ///
+/// `compose_ctx` is `Some` when the REPL session was started in Compose mode
+/// (`--compose`). Compose-mode commands (`:services`, `:mounts`, `:depends`)
+/// use this to access the parsed Compose file and selected service. When
+/// `compose_ctx` is `None`, those commands print a usage hint.
+///
 /// Returns `Ok(true)` normally or `Ok(false)` when the command signals exit.
 /// The caller is responsible for exiting the loop on `Exit`.
 ///
@@ -126,6 +131,7 @@ pub fn run_repl(state: &mut PreviewState, config: &ReplConfig) -> anyhow::Result
 pub fn dispatch(
     state: &mut PreviewState,
     cmd: ParsedCommand,
+    compose_ctx: Option<&ComposeContext>,
     writer: &mut impl Write,
 ) -> Result<bool, ReplError> {
     match cmd {
@@ -172,7 +178,13 @@ pub fn dispatch(
             explain::execute(state, &path, writer)?;
         }
         ParsedCommand::Mounts => {
-            mounts::execute(state, writer)?;
+            mounts::execute(state, compose_ctx, writer)?;
+        }
+        ParsedCommand::Services => {
+            services::execute(compose_ctx, writer)?;
+        }
+        ParsedCommand::Depends => {
+            depends::execute(compose_ctx, writer)?;
         }
         ParsedCommand::Exit => {
             return Ok(false);
@@ -224,7 +236,10 @@ mod tests {
     fn dispatch_str(state: &mut PreviewState, input: &str) -> Result<(bool, String), ReplError> {
         let cmd = parse_input(input);
         let mut buf = Vec::new();
-        let cont = dispatch(state, cmd, &mut buf)?;
+        // Pass None for compose_ctx — all standard REPL tests operate in
+        // single-Dockerfile mode. Compose-mode command tests live in
+        // the respective custom module test suites.
+        let cont = dispatch(state, cmd, None, &mut buf)?;
         Ok((cont, String::from_utf8(buf).expect("utf-8")))
     }
 
@@ -326,7 +341,7 @@ mod tests {
         let mut state = PreviewState::default();
         let cmd = ParsedCommand::Exit;
         let mut buf = Vec::new();
-        let cont = dispatch(&mut state, cmd, &mut buf).expect("should succeed");
+        let cont = dispatch(&mut state, cmd, None, &mut buf).expect("should succeed");
         assert!(!cont, "exit must return false to signal loop termination");
     }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -393,10 +393,13 @@ mod tests {
         state.cwd = PathBuf::from("/app");
         let (cont, out) = dispatch_str(&mut state, "ls -l").expect("ls -l should succeed");
         assert!(cont);
-        // Directories get `d` prefix, files get `-` prefix in long format.
+        // /app contains only regular files (main.rs, lib.rs). In long format each line
+        // must start with `-` (file indicator). Verify at least one line starts with `-`
+        // so we know the type prefix is actually being emitted, not just present incidentally.
+        let has_file_prefix = out.lines().any(|l| l.starts_with('-'));
         assert!(
-            out.contains('d') || out.contains('-'),
-            "long format must include type prefix, got: {out}"
+            has_file_prefix,
+            "long format must emit lines starting with '-' for regular files, got: {out:?}"
         );
     }
 

--- a/src/repl/parse.rs
+++ b/src/repl/parse.rs
@@ -63,6 +63,8 @@ pub enum ParsedCommand {
     },
     /// `:reload` — re-read and re-process the Dockerfile.
     Reload,
+    /// `:mounts` — list all volume mount shadows applied by the Compose engine.
+    Mounts,
     /// The input was empty or only whitespace.
     Empty,
     /// The input did not match any known command.
@@ -110,6 +112,7 @@ pub fn parse_input(line: &str) -> ParsedCommand {
         ":history" => ParsedCommand::History,
         ":installed" => ParsedCommand::Installed,
         ":reload" => ParsedCommand::Reload,
+        ":mounts" => ParsedCommand::Mounts,
         _ => ParsedCommand::Unknown {
             input: trimmed.to_string(),
         },
@@ -812,6 +815,29 @@ mod tests {
             parse_input("WHICH curl"),
             ParsedCommand::Unknown {
                 input: "WHICH curl".to_string()
+            }
+        );
+    }
+
+    // --- :mounts ---
+
+    #[test]
+    fn mounts_bare_returns_mounts() {
+        assert_eq!(parse_input(":mounts"), ParsedCommand::Mounts);
+    }
+
+    #[test]
+    fn mounts_with_trailing_whitespace_returns_mounts() {
+        assert_eq!(parse_input(":mounts  "), ParsedCommand::Mounts);
+    }
+
+    #[test]
+    fn mounts_uppercase_is_unknown() {
+        // Custom commands are case-sensitive — :MOUNTS is not :mounts.
+        assert_eq!(
+            parse_input(":MOUNTS"),
+            ParsedCommand::Unknown {
+                input: ":MOUNTS".to_string()
             }
         );
     }

--- a/src/repl/parse.rs
+++ b/src/repl/parse.rs
@@ -65,6 +65,10 @@ pub enum ParsedCommand {
     Reload,
     /// `:mounts` — list all volume mount shadows applied by the Compose engine.
     Mounts,
+    /// `:services` — list all services in the Compose file (Compose mode only).
+    Services,
+    /// `:depends` — render the dependency tree for the selected service (Compose mode only).
+    Depends,
     /// The input was empty or only whitespace.
     Empty,
     /// The input did not match any known command.
@@ -113,6 +117,8 @@ pub fn parse_input(line: &str) -> ParsedCommand {
         ":installed" => ParsedCommand::Installed,
         ":reload" => ParsedCommand::Reload,
         ":mounts" => ParsedCommand::Mounts,
+        ":services" => ParsedCommand::Services,
+        ":depends" => ParsedCommand::Depends,
         _ => ParsedCommand::Unknown {
             input: trimmed.to_string(),
         },
@@ -815,6 +821,50 @@ mod tests {
             parse_input("WHICH curl"),
             ParsedCommand::Unknown {
                 input: "WHICH curl".to_string()
+            }
+        );
+    }
+
+    // --- :services ---
+
+    #[test]
+    fn services_bare_returns_services() {
+        assert_eq!(parse_input(":services"), ParsedCommand::Services);
+    }
+
+    #[test]
+    fn services_with_trailing_whitespace_returns_services() {
+        assert_eq!(parse_input(":services  "), ParsedCommand::Services);
+    }
+
+    #[test]
+    fn services_uppercase_is_unknown() {
+        assert_eq!(
+            parse_input(":SERVICES"),
+            ParsedCommand::Unknown {
+                input: ":SERVICES".to_string()
+            }
+        );
+    }
+
+    // --- :depends ---
+
+    #[test]
+    fn depends_bare_returns_depends() {
+        assert_eq!(parse_input(":depends"), ParsedCommand::Depends);
+    }
+
+    #[test]
+    fn depends_with_trailing_whitespace_returns_depends() {
+        assert_eq!(parse_input(":depends  "), ParsedCommand::Depends);
+    }
+
+    #[test]
+    fn depends_uppercase_is_unknown() {
+        assert_eq!(
+            parse_input(":DEPENDS"),
+            ParsedCommand::Unknown {
+                input: ":DEPENDS".to_string()
             }
         );
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,16 +4,16 @@ Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
 Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
-- [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — implementation complete, 27 new tests (18 unit + 9 integration), all 635 tests passing
+- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
 
 ## Up next
-- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
 - [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
 - [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
 - [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 
+- [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — merged [#53](https://github.com/automatedtomato/demu/pull/53)
 - [x] [#42](https://github.com/automatedtomato/demu/issues/42) feat: `COPY --from=<stage>` cross-stage file copying — merged [#45](https://github.com/automatedtomato/demu/pull/45)
 - [x] [#41](https://github.com/automatedtomato/demu/issues/41) feat: multi-stage build support + `--stage` CLI flag — merged [#44](https://github.com/automatedtomato/demu/pull/44)
 - [x] [#40](https://github.com/automatedtomato/demu/issues/40) feat: `:explain <path>` REPL command

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,15 +4,15 @@ Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
 Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
-- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
+- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
 
 ## Up next
-- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
 - [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
 - [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 
+- [x] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags — merged [#56](https://github.com/automatedtomato/demu/pull/56)
 - [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — merged [#53](https://github.com/automatedtomato/demu/pull/53)
 - [x] [#42](https://github.com/automatedtomato/demu/issues/42) feat: `COPY --from=<stage>` cross-stage file copying — merged [#45](https://github.com/automatedtomato/demu/pull/45)
 - [x] [#41](https://github.com/automatedtomato/demu/issues/41) feat: multi-stage build support + `--stage` CLI flag — merged [#44](https://github.com/automatedtomato/demu/pull/44)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,11 +1,16 @@
 # demu — task tracking
 
-Milestone: [Release v0.3.0](https://github.com/automatedtomato/demu/milestone/3)
-Tracking issue: [#39](https://github.com/automatedtomato/demu/issues/39)
+Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
+Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
+- [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — implementation complete, 27 new tests (18 unit + 9 integration), all 635 tests passing
 
 ## Up next
+- [ ] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags
+- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
+- [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
+- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,15 +1,15 @@
 # demu — task tracking
 
-Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
-Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
+v0.4.0 complete. Planning next milestone.
 
 ## In progress
-- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Up next
 
 ## Done
 
+- [x] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands — merged [#59](https://github.com/automatedtomato/demu/pull/59)
+- [x] [#47](https://github.com/automatedtomato/demu/issues/47) feat: v0.4.0 Compose service preview [parent] — all child issues merged
 - [x] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model — merged [#58](https://github.com/automatedtomato/demu/pull/58)
 - [x] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge — merged [#57](https://github.com/automatedtomato/demu/pull/57)
 - [x] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags — merged [#56](https://github.com/automatedtomato/demu/pull/56)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,15 @@ v0.4.0 complete. Planning next milestone.
 
 ## In progress
 
-## Up next
+## Up next (post-v0.4.0 backlog — from code/security reviews)
+
+- [ ] [#60](https://github.com/automatedtomato/demu/issues/60) security: path traversal in compose engine — build.context not containment-checked [HIGH]
+- [ ] [#61](https://github.com/automatedtomato/demu/issues/61) fix: working_dir relative-path escape in virtual FS
+- [ ] [#62](https://github.com/automatedtomato/demu/issues/62) fix: parse_env_file does not strip inline comments or quoted values
+- [ ] [#63](https://github.com/automatedtomato/demu/issues/63) fix: :depends/:services silent wrong output when selected_service not in map
+- [ ] [#64](https://github.com/automatedtomato/demu/issues/64) fix: :depends DFS expands shared subtrees multiple times without warning
+- [ ] [#65](https://github.com/automatedtomato/demu/issues/65) refactor: ReplError::InvalidArguments wrong for I/O write failures
+- [ ] [#66](https://github.com/automatedtomato/demu/issues/66) fix: --service without --compose silently ignored
 
 ## Done
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,22 +1,24 @@
 # demu — task tracking
 
-v0.4.0 complete. Planning next milestone.
+Post-v0.4.0 fixes complete. Planning next milestone.
 
 ## In progress
 
-## Up next (post-v0.4.0 backlog — from code/security reviews)
-
-- [ ] [#60](https://github.com/automatedtomato/demu/issues/60) security: path traversal in compose engine — build.context not containment-checked [HIGH]
-- [ ] [#61](https://github.com/automatedtomato/demu/issues/61) fix: working_dir relative-path escape in virtual FS
-- [ ] [#62](https://github.com/automatedtomato/demu/issues/62) fix: parse_env_file does not strip inline comments or quoted values
-- [ ] [#63](https://github.com/automatedtomato/demu/issues/63) fix: :depends/:services silent wrong output when selected_service not in map
-- [ ] [#64](https://github.com/automatedtomato/demu/issues/64) fix: :depends DFS expands shared subtrees multiple times without warning
-- [ ] [#65](https://github.com/automatedtomato/demu/issues/65) refactor: ReplError::InvalidArguments wrong for I/O write failures
-- [ ] [#66](https://github.com/automatedtomato/demu/issues/66) fix: --service without --compose silently ignored
+## Up next
 
 ## Done
 
-- [x] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands — merged [#59](https://github.com/automatedtomato/demu/pull/59)
+- [x] [#60](https://github.com/automatedtomato/demu/issues/60) security: path traversal in compose engine — merged [#67](https://github.com/automatedtomato/demu/pull/67)
+- [x] [#61](https://github.com/automatedtomato/demu/issues/61) fix: working_dir escape — merged [#67](https://github.com/automatedtomato/demu/pull/67)
+- [x] [#62](https://github.com/automatedtomato/demu/issues/62) fix: parse_env_file comments/quotes — merged [#67](https://github.com/automatedtomato/demu/pull/67)
+- [x] [#63](https://github.com/automatedtomato/demu/issues/63) fix: :depends/:services invalid service warning — merged [#68](https://github.com/automatedtomato/demu/pull/68)
+- [x] [#64](https://github.com/automatedtomato/demu/issues/64) fix: :depends two-set DFS diamond deduplication — merged [#68](https://github.com/automatedtomato/demu/pull/68)
+- [x] [#65](https://github.com/automatedtomato/demu/issues/65) refactor: ReplError::Io variant — merged [#70](https://github.com/automatedtomato/demu/pull/70)
+- [x] [#66](https://github.com/automatedtomato/demu/issues/66) fix: --service without --compose warning — merged [#69](https://github.com/automatedtomato/demu/pull/69)
+
+## Done (v0.4.0 and earlier)
+
+- [x] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands (:services, :mounts, :depends) — merged [#59](https://github.com/automatedtomato/demu/pull/59)
 - [x] [#47](https://github.com/automatedtomato/demu/issues/47) feat: v0.4.0 Compose service preview [parent] — all child issues merged
 - [x] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model — merged [#58](https://github.com/automatedtomato/demu/pull/58)
 - [x] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge — merged [#57](https://github.com/automatedtomato/demu/pull/57)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,14 +4,14 @@ Milestone: [Release v0.4.0](https://github.com/automatedtomato/demu/milestone/4)
 Tracking issue: [#47](https://github.com/automatedtomato/demu/issues/47)
 
 ## In progress
-- [ ] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge
+- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Up next
-- [ ] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model
-- [ ] [#52](https://github.com/automatedtomato/demu/issues/52) feat: REPL Compose commands
 
 ## Done
 
+- [x] [#51](https://github.com/automatedtomato/demu/issues/51) feat: mount shadow model — merged [#58](https://github.com/automatedtomato/demu/pull/58)
+- [x] [#50](https://github.com/automatedtomato/demu/issues/50) feat: Compose engine — service merge — merged [#57](https://github.com/automatedtomato/demu/pull/57)
 - [x] [#49](https://github.com/automatedtomato/demu/issues/49) feat: CLI `--compose` and `--service` flags — merged [#56](https://github.com/automatedtomato/demu/pull/56)
 - [x] [#48](https://github.com/automatedtomato/demu/issues/48) feat: Compose YAML parser — merged [#53](https://github.com/automatedtomato/demu/pull/53)
 - [x] [#42](https://github.com/automatedtomato/demu/issues/42) feat: `COPY --from=<stage>` cross-stage file copying — merged [#45](https://github.com/automatedtomato/demu/pull/45)

--- a/tasks/v0.4.0-plan.md
+++ b/tasks/v0.4.0-plan.md
@@ -1,0 +1,394 @@
+# v0.4.0 Plan — Compose Service Preview
+
+## Goal
+
+A user can run:
+
+```bash
+demu --compose -f compose.yaml --service api
+```
+
+…and get the same interactive preview shell they know from single Dockerfiles — but now the preview reflects the full Compose service view: its Dockerfile-derived filesystem, merged environment variables, and mount metadata.
+
+---
+
+## User stories
+
+**As a developer debugging a Compose setup**, I want to inspect what the `api` service's container would look like — files, env vars, and mounts — without starting anything.
+
+**As someone reviewing a Compose change**, I want to see which paths a bind mount would shadow, so I can spot accidental overwrites before they happen in production.
+
+**As a learner**, I want to type `:services` and see all services and their relationships, and `:mounts` to understand what is overlaid on what.
+
+---
+
+## What changes
+
+### New modules
+
+| Module | Purpose |
+|--------|---------|
+| `parser/compose.rs` | Parse `compose.yaml` into a typed `ComposeFile` model |
+| `model/compose.rs` | Typed model: `ComposeFile`, `Service`, `BuildConfig`, `VolumeSpec`, `EnvSource` |
+| `engine/compose.rs` | Service selection, Dockerfile resolution, env merge, mount model |
+| `repl/custom/services.rs` | `:services` command |
+| `repl/custom/mounts.rs` | `:mounts` command |
+| `repl/custom/depends.rs` | `:depends` command |
+
+### Extended modules
+
+| Module | Change |
+|--------|--------|
+| `src/cli.rs` | `--compose` / `--compose-file` and `--service` flags; routing logic |
+| `src/main.rs` | Branch on `--compose` → new Compose pipeline |
+| `src/repl/parse.rs` | Dispatch `:services`, `:mounts`, `:depends` |
+| `src/repl/mod.rs` | Pass `ComposeContext` into REPL loop for Compose-aware commands |
+| `src/model/state.rs` | `MountInfo` already referenced in `Provenance`; populate from Compose mounts |
+| `src/repl/config.rs` | `ReplConfig` gains optional `ComposeContext` |
+
+---
+
+## Features / child issues
+
+### Feature 1 — Compose YAML parser
+
+**Scope:** Parse `docker-compose.yml` / `compose.yaml` into a typed Rust model. No engine logic — pure parsing.
+
+**Fields to handle:**
+
+```yaml
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: myapp:latest         # image-only fallback
+    environment:
+      - KEY=value
+      - KEY                     # inherit from host env (record as unresolved)
+    env_file:
+      - .env
+    volumes:
+      - ./src:/app/src
+      - data:/var/lib/data
+    working_dir: /app
+    depends_on:
+      - db
+    ports:
+      - "8080:80"               # metadata only, not simulated
+
+volumes:
+  data:
+```
+
+**Parser model:**
+
+```rust
+pub struct ComposeFile {
+    pub services: BTreeMap<String, Service>,
+    pub volumes: BTreeMap<String, VolumeDefinition>,
+}
+
+pub struct Service {
+    pub name: String,
+    pub build: Option<BuildConfig>,
+    pub image: Option<String>,
+    pub environment: Vec<EnvEntry>,
+    pub env_file: Vec<PathBuf>,
+    pub volumes: Vec<VolumeSpec>,
+    pub working_dir: Option<PathBuf>,
+    pub depends_on: Vec<String>,
+    pub ports: Vec<String>,          // raw strings, metadata only
+}
+
+pub struct BuildConfig {
+    pub context: PathBuf,
+    pub dockerfile: PathBuf,         // defaults to "Dockerfile"
+}
+
+pub enum EnvEntry {
+    KeyValue { key: String, value: String },
+    KeyOnly { key: String },         // value comes from host env (unresolved in preview)
+}
+
+pub enum VolumeSpec {
+    Bind { host_path: PathBuf, container_path: PathBuf, read_only: bool },
+    Named { volume_name: String, container_path: PathBuf, read_only: bool },
+    Anonymous { container_path: PathBuf },
+}
+```
+
+**Parser approach:** Hand-rolled YAML parsing is impractical. Use the `serde_yaml` crate (already widely used in the Rust ecosystem; no runtime overhead, compile-time deserialization). Add `serde_yaml` and `serde` as dependencies.
+
+**Public interface:**
+
+```rust
+pub fn parse_compose(input: &str) -> Result<ComposeFile, ComposeParseError>
+```
+
+**Error model:**
+
+```rust
+pub enum ComposeParseError {
+    InvalidYaml { message: String },
+    MissingServicesKey,
+    InvalidService { name: String, message: String },
+}
+```
+
+**Tests:** Fixture-based. Create `tests/fixtures/compose/` with representative compose files. Unit tests for each field variant (env list, env dict, short volume, long volume, build shorthand).
+
+**Acceptance criteria:**
+- `parse_compose` returns typed `ComposeFile` for a valid file
+- `ComposeParseError` returned for missing/malformed input
+- Ports, `depends_on`, and `env_file` are recorded as metadata (no resolution)
+- Volumes parsed into `Bind`, `Named`, or `Anonymous` variants
+- Unknown top-level keys are tolerated (forward-compat)
+
+---
+
+### Feature 2 — CLI flags: `--compose` and `--service`
+
+**Scope:** Extend the CLI to accept Compose-mode flags and route to the Compose pipeline.
+
+**New flags:**
+
+```
+--compose              Switch to Compose mode (use with -f compose.yaml)
+--service <name>       Service to inspect (required when --compose is set)
+```
+
+`-f` is reused for the compose file path.
+
+**Routing logic in `main.rs`:**
+
+```
+if cli.compose:
+    → parse compose file
+    → validate service name
+    → run compose pipeline
+    → enter REPL with ComposeContext
+else:
+    → existing Dockerfile pipeline (unchanged)
+```
+
+**Validation:**
+- If `--compose` is set and `--service` is absent: bail with `"--service <name> is required in compose mode"`
+- If the named service does not exist in the parsed compose file: bail with a list of available service names (sanitized)
+- If `--compose` is set and `-f` points to a file that fails to parse as YAML: bail with the parse error
+
+**`ReplConfig` change:** Add `compose_context: Option<ComposeContext>` where `ComposeContext` holds the full `ComposeFile` and the selected `Service` name. This makes it available for `:reload` (which re-parses the compose file) and REPL commands.
+
+**Tests:** Unit tests for flag parsing; integration tests for the validation error paths.
+
+**Acceptance criteria:**
+- `demu --compose -f compose.yaml --service api` reaches the Compose pipeline
+- `demu --compose -f compose.yaml` (no `--service`) exits with a clear error
+- `demu --compose -f compose.yaml --service nonexistent` lists available services
+- `demu -f Dockerfile` still works unchanged
+
+---
+
+### Feature 3 — Compose engine: service merge
+
+**Scope:** Given a parsed `ComposeFile` and a selected service name, produce a `PreviewState` that reflects the service's full view: Dockerfile-derived filesystem + Compose-level env and working_dir overrides.
+
+**Pipeline:**
+
+```
+1. Select service from ComposeFile
+2. Resolve Dockerfile path:
+   - If service.build is Some: use build.context + build.dockerfile
+   - If service.build is None and service.image is Some: start from empty fs,
+     record image name as active_stage, emit Warning::ImageOnlyService
+3. Read and parse the Dockerfile (if found)
+4. Run engine::run() on the Dockerfile instructions
+5. Apply Compose-level overrides to the resulting PreviewState:
+   a. environment entries: merge into state.env (Compose values win over Dockerfile ENV)
+   b. working_dir: if set, override state.cwd
+   c. env_file: read each .env file (if found), merge into state.env;
+      emit Warning::EnvFileNotFound if file is missing
+6. Record mounts in state (see Feature 4)
+7. Return ComposeEngineOutput { state, compose_file, selected_service }
+```
+
+**New warning variants:**
+
+```rust
+Warning::ImageOnlyService { image: String }
+// "service uses image '{image}' with no build context — filesystem is empty"
+
+Warning::EnvFileNotFound { path: PathBuf }
+// "env_file '{path}' not found — skipped"
+
+Warning::UnresolvedEnvKey { key: String }
+// "environment key '{key}' has no value in compose file or host env — skipped"
+```
+
+**Public interface:**
+
+```rust
+pub fn run_compose(
+    compose_file: &ComposeFile,
+    service_name: &str,
+    compose_dir: &Path,      // parent of the compose.yaml file
+) -> Result<ComposeEngineOutput, ComposeEngineError>
+```
+
+**Tests:** Integration fixture — a compose file pointing at an existing fixture Dockerfile. Tests for env merge precedence, `working_dir` override, missing `env_file` warning, image-only service.
+
+**Acceptance criteria:**
+- Dockerfile-derived filesystem is present in preview state
+- Compose `environment` entries are visible via `env` command in REPL
+- Compose `working_dir` overrides Dockerfile `WORKDIR` in `pwd`
+- Missing `env_file` emits warning, does not crash
+- Image-only service produces empty fs with clear warning
+
+---
+
+### Feature 4 — Mount shadow model
+
+**Scope:** Model bind mounts and named volumes as metadata and surface them in `:explain` and `:mounts`. Do not simulate actual file contents from the host — just record what would be shadowed.
+
+**MountInfo model** (already referenced in `Provenance.shadowed_by_mount`):
+
+```rust
+pub struct MountInfo {
+    pub kind: MountKind,
+    pub container_path: PathBuf,
+    pub read_only: bool,
+    pub description: String,   // human-readable, e.g. "./src → /app/src (bind)"
+}
+
+pub enum MountKind {
+    Bind { host_path: PathBuf },
+    Named { volume_name: String },
+    Anonymous,
+}
+```
+
+**Shadow detection logic:**
+
+For each `VolumeSpec` in the selected service:
+1. Determine `container_path`
+2. Walk `state.fs` — for every node whose path starts with `container_path`, set `node.provenance.shadowed_by_mount = Some(MountInfo { ... })`
+3. Also insert a directory node at `container_path` itself (if not already present) with `shadowed_by_mount` set — representing the mount point
+
+**`state.mounts: Vec<MountInfo>`** — add this field to `PreviewState` so `:mounts` can enumerate all mounts without walking the entire fs.
+
+**`:explain` integration:** When `provenance.shadowed_by_mount` is `Some`, the `:explain` output already has a `Shadowed by:` line — it will now be populated with the mount description.
+
+**Tests:** Engine unit tests for shadow detection; integration test with fixture compose file that has bind and named volumes.
+
+**Acceptance criteria:**
+- `state.mounts` contains all volumes from the service
+- Files under a mounted path have `shadowed_by_mount` populated
+- `:explain /app/src/main.rs` shows `Shadowed by: bind mount ./src → /app/src`
+- Named volumes and anonymous volumes are represented
+- Paths not under any mount are unaffected
+
+---
+
+### Feature 5 — REPL Compose commands
+
+**Scope:** Three new custom REPL commands, available only when the REPL session has a `ComposeContext`.
+
+**`:services`**
+
+Lists all services in the compose file with their build config and dependencies.
+
+```
+api     build: ./api/Dockerfile   depends: db, redis
+db      image: postgres:15
+redis   image: redis:7
+```
+
+Selecting a different service for inspection is out of scope for v0.4 (`:service <name>` switch is v0.5+).
+
+**`:mounts`**
+
+Lists all mounts for the active service, showing what each overlays.
+
+```
+bind    ./src       → /app/src          (read-write)   shadows 3 file(s)
+named   data        → /var/lib/data     (read-write)
+anon                → /tmp              (read-write)
+```
+
+**`:depends`**
+
+Shows the dependency tree for the selected service.
+
+```
+api
+  └─ db
+  └─ redis
+```
+
+Cycles in `depends_on` are detected and reported as a warning rather than infinite-looping.
+
+**Guard:** All three commands check for `ComposeContext`. When run in single-Dockerfile mode, they print:
+
+```
+:services is only available in compose mode (--compose -f compose.yaml --service <name>)
+```
+
+**REPL parse changes:** `parse.rs` gets `ParsedCommand::Services`, `ParsedCommand::Mounts`, `ParsedCommand::Depends`. Dispatch in `mod.rs` routes to the handler modules with `ComposeContext`.
+
+**Tests:** Unit tests for each command's output format against a fixture `ComposeContext`. Tests for the guard message in non-Compose mode.
+
+**Acceptance criteria:**
+- `:services` lists all services with type (build vs image) and `depends_on`
+- `:mounts` lists all mounts with paths, direction, and shadow count
+- `:depends` renders the dependency tree
+- All three commands print a clear error in single-Dockerfile mode
+- Dependency cycle in compose file emits a warning, does not hang
+
+---
+
+## Dependency graph
+
+```
+Feature 1 (parser)
+    └─ Feature 2 (CLI)
+         └─ Feature 3 (engine)
+              ├─ Feature 4 (mounts)    ← can develop alongside Feature 3
+              └─ Feature 5 (REPL)     ← depends on 3 and 4
+```
+
+Recommended implementation order: **1 → 2 → 3 → 4 → 5**
+
+Features 3 and 4 can overlap since the mount model is independent of the Dockerfile pipeline step.
+
+---
+
+## Out of scope for v0.4.0
+
+- Resolving `KeyOnly` env entries from the host environment (recorded as unresolved; shown as `KEY=<from host>` in `env` output)
+- Full YAML variable interpolation (`${VAR:-default}`)
+- Compose profiles
+- `extends` and anchors beyond what `serde_yaml` handles automatically
+- Network metadata
+- `healthcheck`, `command`, `entrypoint` parsing
+- Switching between services within the REPL (`:service <name>`)
+- Image filesystem extraction (image-only services start from empty fs)
+- `docker-compose.override.yml` merging
+
+---
+
+## Acceptance bar for v0.4.0
+
+The milestone is complete when a user can:
+
+1. Run `demu --compose -f compose.yaml --service api` and enter the REPL
+2. See the Dockerfile-derived filesystem merged with Compose `environment`
+3. Type `:services` to see all services
+4. Type `:mounts` to see what is mounted where
+5. Type `:depends` to see service dependencies
+6. Type `:explain /app/src/main.rs` and see a `Shadowed by: bind mount` line
+
+---
+
+## New dependency to add
+
+- `serde_yaml = "0.9"` + `serde = { version = "1", features = ["derive"] }` — for Compose YAML parsing

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -252,8 +252,8 @@ fn malformed_dockerfile_exits_one() {
         "parse error must begin with 'demu:' prefix, got: {stderr}"
     );
     assert!(
-        stderr.contains("parse") || stderr.contains("failed"),
-        "parse error must mention parse failure, got: {stderr}"
+        stderr.contains("parse"),
+        "parse error must mention 'parse', got: {stderr}"
     );
 }
 
@@ -325,6 +325,30 @@ fn stage_flag_exits_one_with_not_implemented_error() {
     assert!(
         stderr.contains("available stages"),
         "--stage error must list 'available stages', got: {stderr}"
+    );
+}
+
+// ── test 10b: --stage <valid-name> selects correct stage ─────────────────────
+
+#[test]
+fn valid_stage_name_exits_zero() {
+    // A two-stage Dockerfile with a named builder stage. Passing --stage builder
+    // should select the builder stage and exit 0 with EOF stdin.
+    let df = temp_dockerfile(
+        "FROM ubuntu:22.04 AS builder\nWORKDIR /build\nRUN echo done\nFROM scratch\nCOPY --from=builder /build /out\n",
+    );
+    let output = demu()
+        .args(["-f", df.path().to_str().expect("path"), "--stage", "builder"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--stage builder on valid two-stage Dockerfile must exit 0, got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -27,6 +27,23 @@ fn temp_dockerfile(content: &str) -> tempfile::NamedTempFile {
     f
 }
 
+/// Create a temporary Compose YAML file containing `content` and return its path.
+///
+/// The returned `tempfile::NamedTempFile` keeps the file alive for the
+/// duration of the test — do not drop it before `Command::status()` returns.
+fn temp_compose_file(content: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    f.write_all(content.as_bytes()).expect("write compose file");
+    f
+}
+
+/// Minimal valid compose YAML with an "api" service.
+const COMPOSE_WITH_API: &str = "services:\n  api:\n    image: myapp:latest\n";
+
+/// Compose YAML with two services for service-list testing.
+const COMPOSE_WITH_API_AND_DB: &str =
+    "services:\n  api:\n    image: myapp:latest\n  db:\n    image: postgres:15\n";
+
 // ── test 1: missing --file flag exits non-zero ────────────────────────────────
 
 #[test]
@@ -311,7 +328,169 @@ fn stage_flag_exits_one_with_not_implemented_error() {
     );
 }
 
-// ── test 11: empty Dockerfile (no instructions) exits 0 ──────────────────────
+// ── Compose mode tests ────────────────────────────────────────────────────────
+
+// ── test 11: --compose without --service exits 1 with clear error ─────────────
+
+#[test]
+fn compose_without_service_flag_exits_one() {
+    // `--compose` requires `--service`. Missing `--service` must exit 1 with
+    // a message that names the missing flag so the user knows how to fix it.
+    let compose = temp_compose_file(COMPOSE_WITH_API);
+
+    let output = demu()
+        .args(["--compose", "-f", compose.path().to_str().expect("path")])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--compose without --service must exit 1, got: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--service") || stderr.contains("service"),
+        "error must mention '--service', got: {stderr}"
+    );
+    assert!(
+        stderr.contains("required") || stderr.contains("compose mode"),
+        "error must say 'required' or 'compose mode', got: {stderr}"
+    );
+}
+
+// ── test 12: --compose with nonexistent service exits 1 and lists services ────
+
+#[test]
+fn compose_nonexistent_service_exits_one_with_available_list() {
+    // When `--service` names a service that does not exist in the Compose file,
+    // `demu` must exit 1 and list the available service names so the user knows
+    // what to pass.
+    let compose = temp_compose_file(COMPOSE_WITH_API_AND_DB);
+
+    let output = demu()
+        .args([
+            "--compose",
+            "-f",
+            compose.path().to_str().expect("path"),
+            "--service",
+            "nonexistent",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--compose with nonexistent service must exit 1, got: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "error must say 'not found', got: {stderr}"
+    );
+    // Both service names from the compose file must appear so the user can pick.
+    assert!(
+        stderr.contains("api"),
+        "error must list available service 'api', got: {stderr}"
+    );
+    assert!(
+        stderr.contains("db"),
+        "error must list available service 'db', got: {stderr}"
+    );
+}
+
+// ── test 13: --compose with invalid YAML exits 1 with parse error ─────────────
+
+#[test]
+fn compose_invalid_yaml_exits_one() {
+    // A file that is not valid YAML must cause `demu` to exit 1 with a message
+    // that begins with `"demu:"` and references the parse failure.
+    let compose = temp_compose_file("{ not: valid: yaml: [\n");
+
+    let output = demu()
+        .args([
+            "--compose",
+            "-f",
+            compose.path().to_str().expect("path"),
+            "--service",
+            "api",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "invalid YAML in compose mode must exit 1, got: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("demu:"),
+        "error must begin with 'demu:', got: {stderr}"
+    );
+}
+
+// ── test 14: valid --compose + --service exits 0 with EOF stdin ───────────────
+
+#[test]
+fn compose_valid_service_with_eof_stdin_exits_zero() {
+    // The happy path: a valid Compose file and a known service name. With stdin
+    // closed immediately, the REPL hits EOF and exits cleanly.
+    let compose = temp_compose_file(COMPOSE_WITH_API);
+
+    let output = demu()
+        .args([
+            "--compose",
+            "-f",
+            compose.path().to_str().expect("path"),
+            "--service",
+            "api",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert!(
+        output.status.success(),
+        "--compose with valid service + EOF stdin must exit 0, got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── test 15: Dockerfile pipeline unchanged in compose mode addition ───────────
+
+#[test]
+fn dockerfile_pipeline_unchanged_after_compose_addition() {
+    // Regression guard: `demu -f Dockerfile` must still work exactly as before.
+    // This ensures the compose branch does not accidentally break the existing flow.
+    let dockerfile = temp_dockerfile("FROM scratch\n");
+
+    let output = demu()
+        .args(["-f", dockerfile.path().to_str().expect("path")])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert!(
+        output.status.success(),
+        "existing Dockerfile pipeline must still exit 0, got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── test 11 (original): empty Dockerfile (no instructions) exits 0 ───────────
 
 #[test]
 fn empty_dockerfile_with_eof_stdin_exits_zero() {

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -338,7 +338,12 @@ fn valid_stage_name_exits_zero() {
         "FROM ubuntu:22.04 AS builder\nWORKDIR /build\nRUN echo done\nFROM scratch\nCOPY --from=builder /build /out\n",
     );
     let output = demu()
-        .args(["-f", df.path().to_str().expect("path"), "--stage", "builder"])
+        .args([
+            "-f",
+            df.path().to_str().expect("path"),
+            "--stage",
+            "builder",
+        ])
         .stdin(Stdio::null())
         .output()
         .expect("failed to run demu");

--- a/tests/cli_entrypoint.rs
+++ b/tests/cli_entrypoint.rs
@@ -490,6 +490,43 @@ fn dockerfile_pipeline_unchanged_after_compose_addition() {
     );
 }
 
+// ── test 16: --service without --compose emits warning but still exits 0 ──────
+
+#[test]
+fn service_without_compose_emits_warning() {
+    // Passing --service without --compose should not abort, but should emit
+    // a clear warning to stderr so the user is not silently misled.
+    let dockerfile = temp_dockerfile("FROM scratch\n");
+
+    let output = demu()
+        .args([
+            "-f",
+            dockerfile.path().to_str().expect("path"),
+            "--service",
+            "api",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run demu");
+
+    assert!(
+        output.status.success(),
+        "--service without --compose must still exit 0; got: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--service"),
+        "--service without --compose must mention '--service' in the warning; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("warning"),
+        "--service without --compose must be prefixed with 'warning'; got: {stderr}"
+    );
+}
+
 // ── test 11 (original): empty Dockerfile (no instructions) exits 0 ───────────
 
 #[test]

--- a/tests/compose_engine.rs
+++ b/tests/compose_engine.rs
@@ -1,0 +1,238 @@
+// Integration tests for the Compose engine (issue #50).
+//
+// These tests use fixture files under `tests/fixtures/compose/engine/` to
+// exercise the full parse-and-run pipeline end-to-end, asserting on the
+// resulting `PreviewState` fields.
+
+use std::path::{Path, PathBuf};
+
+use demu::{engine::run_compose, model::warning::Warning, parser::compose::parse_compose};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Path to the fixture directory for compose engine tests.
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/compose/engine")
+}
+
+/// Parse a compose file fixture by name and return the `ComposeFile`.
+fn parse_fixture(filename: &str) -> demu::model::compose::ComposeFile {
+    let path = fixture_dir().join(filename);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read fixture '{}': {e}", path.display()));
+    parse_compose(&content)
+        .unwrap_or_else(|e| panic!("failed to parse fixture '{}': {e}", path.display()))
+}
+
+// ── test 1: build service produces Dockerfile filesystem ─────────────────────
+
+#[test]
+fn build_service_produces_dockerfile_filesystem() {
+    // compose_build.yaml points at the Dockerfile in the same directory.
+    // The Dockerfile sets WORKDIR /app, so /app must be in the virtual FS.
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    // /app should exist from the Dockerfile's WORKDIR instruction.
+    let app_path = PathBuf::from("/app");
+    assert!(
+        output.state.fs.contains(&app_path),
+        "virtual fs must contain /app from Dockerfile WORKDIR"
+    );
+
+    // DF_VAR is set in the Dockerfile; compose_build.yaml doesn't override it.
+    assert_eq!(
+        output.state.env.get("DF_VAR").map(String::as_str),
+        Some("from_dockerfile"),
+        "DF_VAR must be set from Dockerfile ENV"
+    );
+}
+
+// ── test 2: compose environment wins over dockerfile ENV ─────────────────────
+
+#[test]
+fn compose_environment_wins_over_dockerfile_env() {
+    // compose_build.yaml: environment: [SHARED=from_compose, COMPOSE_VAR=from_compose]
+    // Dockerfile:         ENV SHARED=from_dockerfile
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    // Compose environment must override Dockerfile ENV for SHARED.
+    assert_eq!(
+        output.state.env.get("SHARED").map(String::as_str),
+        Some("from_compose"),
+        "SHARED must be from Compose environment, not Dockerfile ENV"
+    );
+
+    // COMPOSE_VAR is Compose-only (not in Dockerfile).
+    assert_eq!(
+        output.state.env.get("COMPOSE_VAR").map(String::as_str),
+        Some("from_compose"),
+        "COMPOSE_VAR must be present from Compose environment"
+    );
+}
+
+// ── test 3: working_dir overrides Dockerfile WORKDIR ─────────────────────────
+
+#[test]
+fn working_dir_overrides_dockerfile_workdir() {
+    // compose_build.yaml sets working_dir: /override
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    assert_eq!(
+        output.state.cwd,
+        PathBuf::from("/override"),
+        "cwd must be /override from compose working_dir"
+    );
+
+    // /override must also exist in the virtual filesystem.
+    assert!(
+        output.state.fs.contains(&PathBuf::from("/override")),
+        "virtual fs must contain /override"
+    );
+}
+
+// ── test 4: image-only service has empty filesystem with warning ──────────────
+
+#[test]
+fn image_only_service_empty_fs_with_warning() {
+    let compose = parse_fixture("compose_image_only.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "db", &dir).expect("compose engine must succeed");
+
+    // Filesystem must be empty (no Dockerfile ran).
+    assert_eq!(
+        output.state.fs.iter().count(),
+        0,
+        "image-only service must have empty fs"
+    );
+
+    // ImageOnlyService warning must be present.
+    let has_warning =
+        output.state.warnings.iter().any(
+            |w| matches!(w, Warning::ImageOnlyService { image } if image.contains("postgres")),
+        );
+    assert!(
+        has_warning,
+        "must have ImageOnlyService warning for postgres"
+    );
+}
+
+// ── test 5: image-only service gets compose environment applied ───────────────
+
+#[test]
+fn image_only_service_gets_compose_environment() {
+    // compose_image_only.yaml: environment: [DB_VAR=hello]
+    let compose = parse_fixture("compose_image_only.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "db", &dir).expect("compose engine must succeed");
+
+    assert_eq!(
+        output.state.env.get("DB_VAR").map(String::as_str),
+        Some("hello"),
+        "DB_VAR from compose environment must be applied even for image-only service"
+    );
+}
+
+// ── test 6: env_file is loaded and merged ─────────────────────────────────────
+
+#[test]
+fn env_file_loaded_and_merged() {
+    // compose_env_file.yaml references .env.test, which sets:
+    //   ENV_FILE_VAR=from_env_file
+    //   SHARED=from_env_file
+    // The compose file also sets environment: [SHARED=from_compose]
+    // So SHARED should be "from_compose" (environment wins over env_file).
+    let compose = parse_fixture("compose_env_file.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("compose engine must succeed");
+
+    assert_eq!(
+        output.state.env.get("ENV_FILE_VAR").map(String::as_str),
+        Some("from_env_file"),
+        "ENV_FILE_VAR must be loaded from env_file"
+    );
+
+    // Compose environment wins over env_file for SHARED.
+    assert_eq!(
+        output.state.env.get("SHARED").map(String::as_str),
+        Some("from_compose"),
+        "SHARED: environment entry must win over env_file entry"
+    );
+}
+
+// ── test 7: missing env_file emits warning without crashing ───────────────────
+
+#[test]
+fn missing_env_file_emits_warning_without_crash() {
+    let compose = parse_fixture("compose_missing_env_file.yaml");
+    let dir = fixture_dir();
+
+    // Must not return an error — missing env_file is non-fatal.
+    let output =
+        run_compose(&compose, "api", &dir).expect("missing env_file must not be a fatal error");
+
+    let has_warning = output
+        .state
+        .warnings
+        .iter()
+        .any(|w| matches!(w, Warning::EnvFileNotFound { .. }));
+    assert!(has_warning, "must have EnvFileNotFound warning");
+}
+
+// ── test 8: KeyOnly env emits UnresolvedEnvKey warning ────────────────────────
+
+#[test]
+fn key_only_env_emits_unresolved_warning() {
+    // compose_key_only_env.yaml: environment: [HOST_VAR, DEFINED_VAR=has_value]
+    let compose = parse_fixture("compose_key_only_env.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("should succeed");
+
+    let has_warning = output
+        .state
+        .warnings
+        .iter()
+        .any(|w| matches!(w, Warning::UnresolvedEnvKey { key } if key == "HOST_VAR"));
+    assert!(
+        has_warning,
+        "must have UnresolvedEnvKey warning for HOST_VAR"
+    );
+
+    // HOST_VAR must NOT be in env.
+    assert!(
+        !output.state.env.contains_key("HOST_VAR"),
+        "HOST_VAR must not be in state.env"
+    );
+
+    // DEFINED_VAR must be in env.
+    assert_eq!(
+        output.state.env.get("DEFINED_VAR").map(String::as_str),
+        Some("has_value"),
+        "DEFINED_VAR must be present with correct value"
+    );
+}
+
+// ── test 9: output fields are correct ─────────────────────────────────────────
+
+#[test]
+fn output_selected_service_and_compose_file_are_correct() {
+    let compose = parse_fixture("compose_build.yaml");
+    let dir = fixture_dir();
+
+    let output = run_compose(&compose, "api", &dir).expect("should succeed");
+
+    assert_eq!(output.selected_service, "api");
+    assert!(output.compose_file.services.contains_key("api"));
+}

--- a/tests/compose_fixtures.rs
+++ b/tests/compose_fixtures.rs
@@ -1,0 +1,251 @@
+//! Fixture-based integration tests for the Compose YAML parser.
+//!
+//! These tests load YAML fixture files from `tests/fixtures/compose/` and
+//! assert that the parser produces the expected domain model.  Each test was
+//! written **before** the implementation (TDD red phase) and the
+//! implementation was evolved until all tests passed (green phase).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use demu::model::compose::{BuildConfig, EnvEntry, VolumeDefinition, VolumeSpec};
+use demu::parser::compose::parse_compose;
+use demu::parser::ComposeParseError;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Load and parse the named fixture file, panicking with a helpful message on
+/// failure.
+fn load(name: &str) -> demu::model::compose::ComposeFile {
+    let path = format!("tests/fixtures/compose/{name}");
+    let input = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read fixture {path}: {e}"));
+    parse_compose(&input).unwrap_or_else(|e| panic!("parse failed for {path}: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Full fixture: two services, correct names, build config, env entries, volume
+/// specs, and depends_on.
+#[test]
+fn test_full_compose() {
+    let file = load("full.yaml");
+
+    // Exactly two services.
+    assert_eq!(file.services.len(), 2, "expected 2 services");
+    assert!(file.services.contains_key("api"), "api service missing");
+    assert!(file.services.contains_key("db"), "db service missing");
+
+    // --- api service ---
+    let api = file.services.get("api").expect("api");
+    assert_eq!(api.name, "api");
+
+    // Build config from long form.
+    let build = api.build.as_ref().expect("api build config");
+    assert_eq!(
+        *build,
+        BuildConfig {
+            context: PathBuf::from("./services/api"),
+            dockerfile: PathBuf::from("Dockerfile.dev"),
+        }
+    );
+    assert!(api.image.is_none(), "api should have no image");
+
+    // Environment: list form — NODE_ENV=production + bare DEBUG.
+    assert!(
+        api.environment.contains(&EnvEntry::KeyValue {
+            key: "NODE_ENV".to_string(),
+            value: "production".to_string(),
+        }),
+        "NODE_ENV entry missing"
+    );
+    assert!(
+        api.environment.contains(&EnvEntry::KeyOnly {
+            key: "DEBUG".to_string()
+        }),
+        "DEBUG entry missing"
+    );
+
+    // Volumes: bind mount (non-readonly) + bind mount (readonly).
+    assert!(
+        api.volumes.contains(&VolumeSpec::Bind {
+            host_path: PathBuf::from("./src"),
+            container_path: PathBuf::from("/app/src"),
+            read_only: false,
+        }),
+        "non-readonly bind volume missing"
+    );
+    assert!(
+        api.volumes.contains(&VolumeSpec::Bind {
+            host_path: PathBuf::from("./src"),
+            container_path: PathBuf::from("/app/src"),
+            read_only: true,
+        }),
+        "readonly bind volume missing"
+    );
+
+    // depends_on.
+    assert_eq!(api.depends_on, vec!["db"]);
+
+    // --- db service ---
+    let db = file.services.get("db").expect("db");
+    assert_eq!(db.image.as_deref(), Some("postgres:15"));
+    assert!(db.build.is_none(), "db should have no build config");
+
+    // Environment from dict form.
+    assert!(db.environment.contains(&EnvEntry::KeyValue {
+        key: "POSTGRES_USER".to_string(),
+        value: "app".to_string(),
+    }));
+
+    // Named volume.
+    assert!(db.volumes.contains(&VolumeSpec::Named {
+        volume_name: "pgdata".to_string(),
+        container_path: PathBuf::from("/var/lib/postgresql/data"),
+        read_only: false,
+    }));
+
+    // Top-level volumes declaration.
+    assert!(
+        file.volumes.contains_key("pgdata"),
+        "top-level pgdata volume missing"
+    );
+}
+
+/// Image-only service: `image` is Some, `build` is None.
+#[test]
+fn test_image_only_service() {
+    let file = load("image_only.yaml");
+    let db = file.services.get("db").expect("db service");
+    assert_eq!(db.image.as_deref(), Some("postgres:15"));
+    assert!(
+        db.build.is_none(),
+        "build should be None for image-only service"
+    );
+}
+
+/// Dict form of `environment`: string value + numeric value stringified.
+#[test]
+fn test_env_dict_form() {
+    let file = load("env_dict.yaml");
+    let api = file.services.get("api").expect("api service");
+
+    assert!(api.environment.contains(&EnvEntry::KeyValue {
+        key: "NODE_ENV".to_string(),
+        value: "production".to_string(),
+    }));
+    // Numeric value 3000 must have been stringified.
+    assert!(
+        api.environment.contains(&EnvEntry::KeyValue {
+            key: "PORT".to_string(),
+            value: "3000".to_string(),
+        }),
+        "PORT entry with stringified numeric value missing; got: {:?}",
+        api.environment
+    );
+}
+
+/// Named volume variant with correct fields.
+#[test]
+fn test_volume_named_fixture() {
+    let file = load("volume_named.yaml");
+    let db = file.services.get("db").expect("db service");
+
+    assert!(
+        db.volumes.contains(&VolumeSpec::Named {
+            volume_name: "pgdata".to_string(),
+            container_path: PathBuf::from("/var/lib/postgresql/data"),
+            read_only: false,
+        }),
+        "named pgdata volume missing; got: {:?}",
+        db.volumes
+    );
+
+    let vol_def = file.volumes.get("pgdata").expect("pgdata definition");
+    assert_eq!(*vol_def, VolumeDefinition { external: false });
+}
+
+/// Invalid YAML returns `ComposeParseError::InvalidYaml`.
+#[test]
+fn test_invalid_yaml_error() {
+    let path = "tests/fixtures/compose/invalid.yaml";
+    let input = std::fs::read_to_string(path).expect("fixture readable");
+    let err = parse_compose(&input).expect_err("should fail on invalid YAML");
+    assert!(
+        matches!(err, ComposeParseError::InvalidYaml { .. }),
+        "expected InvalidYaml, got: {err}"
+    );
+}
+
+/// YAML with no `services:` key returns `MissingServicesKey`.
+#[test]
+fn test_missing_services_error() {
+    let yaml = "version: \"3.8\"\nvolumes:\n  data:\n";
+    let err = parse_compose(yaml).expect_err("should fail without services");
+    assert!(
+        matches!(err, ComposeParseError::MissingServicesKey),
+        "expected MissingServicesKey, got: {err}"
+    );
+}
+
+/// Short-form `build: ./app` → `BuildConfig.dockerfile == "Dockerfile"`.
+#[test]
+fn test_build_string_shorthand_fixture() {
+    let yaml = "services:\n  api:\n    build: ./app\n";
+    let file = parse_compose(yaml).expect("should parse");
+    let api = file.services.get("api").expect("api");
+    let build = api.build.as_ref().expect("build");
+    assert_eq!(build.context, PathBuf::from("./app"));
+    assert_eq!(
+        build.dockerfile,
+        PathBuf::from("Dockerfile"),
+        "default dockerfile name should be 'Dockerfile'"
+    );
+}
+
+/// Unknown top-level keys (`networks:`) and service-level keys (`restart:`)
+/// should not cause a parse error.
+#[test]
+fn test_unknown_keys_tolerated_fixture() {
+    let yaml = concat!(
+        "services:\n",
+        "  web:\n",
+        "    image: nginx\n",
+        "    restart: always\n",
+        "networks:\n",
+        "  default:\n",
+    );
+    let result = parse_compose(yaml);
+    assert!(
+        result.is_ok(),
+        "unknown keys should be tolerated, got: {result:?}"
+    );
+}
+
+/// `depends_on` in dict form — only the service name keys should be collected.
+#[test]
+fn test_depends_on_dict_form_fixture() {
+    let yaml = concat!(
+        "services:\n",
+        "  api:\n",
+        "    image: nginx\n",
+        "    depends_on:\n",
+        "      db:\n",
+        "        condition: service_healthy\n",
+        "      cache:\n",
+        "        condition: service_started\n",
+        "  db:\n",
+        "    image: postgres:15\n",
+        "  cache:\n",
+        "    image: redis:7\n",
+    );
+    let file = parse_compose(yaml).expect("should parse");
+    let api = file.services.get("api").expect("api");
+    let mut deps = api.depends_on.clone();
+    deps.sort();
+    assert_eq!(deps, vec!["cache", "db"]);
+}

--- a/tests/fixtures/compose/engine/.env.test
+++ b/tests/fixtures/compose/engine/.env.test
@@ -1,0 +1,3 @@
+# Test env file
+ENV_FILE_VAR=from_env_file
+SHARED=from_env_file

--- a/tests/fixtures/compose/engine/Dockerfile
+++ b/tests/fixtures/compose/engine/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ENV DF_VAR=from_dockerfile
+ENV SHARED=from_dockerfile
+WORKDIR /app

--- a/tests/fixtures/compose/engine/compose_build.yaml
+++ b/tests/fixtures/compose/engine/compose_build.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - SHARED=from_compose
+      - COMPOSE_VAR=from_compose
+    working_dir: /override

--- a/tests/fixtures/compose/engine/compose_env_file.yaml
+++ b/tests/fixtures/compose/engine/compose_env_file.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.test
+    environment:
+      - SHARED=from_compose

--- a/tests/fixtures/compose/engine/compose_image_only.yaml
+++ b/tests/fixtures/compose/engine/compose_image_only.yaml
@@ -1,0 +1,5 @@
+services:
+  db:
+    image: postgres:15
+    environment:
+      - DB_VAR=hello

--- a/tests/fixtures/compose/engine/compose_key_only_env.yaml
+++ b/tests/fixtures/compose/engine/compose_key_only_env.yaml
@@ -1,0 +1,8 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - HOST_VAR
+      - DEFINED_VAR=has_value

--- a/tests/fixtures/compose/engine/compose_missing_env_file.yaml
+++ b/tests/fixtures/compose/engine/compose_missing_env_file.yaml
@@ -1,0 +1,7 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.nonexistent

--- a/tests/fixtures/compose/env_dict.yaml
+++ b/tests/fixtures/compose/env_dict.yaml
@@ -1,0 +1,9 @@
+# Fixture exercising the dict form of `environment` including a numeric value
+# that must be coerced to a string by the parser.
+services:
+  api:
+    image: node:20
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      DEBUG: "false"

--- a/tests/fixtures/compose/full.yaml
+++ b/tests/fixtures/compose/full.yaml
@@ -1,0 +1,29 @@
+# Full fixture: exercises build config, env list, bind volumes, depends_on, and
+# named volumes across two services.
+services:
+  api:
+    build:
+      context: ./services/api
+      dockerfile: Dockerfile.dev
+    environment:
+      - NODE_ENV=production
+      - DEBUG
+    volumes:
+      - ./src:/app/src
+      - ./src:/app/src:ro
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: appdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/tests/fixtures/compose/image_only.yaml
+++ b/tests/fixtures/compose/image_only.yaml
@@ -1,0 +1,4 @@
+# Minimal fixture: single service using a pre-built image with no build config.
+services:
+  db:
+    image: postgres:15

--- a/tests/fixtures/compose/invalid.yaml
+++ b/tests/fixtures/compose/invalid.yaml
@@ -1,0 +1,5 @@
+# Syntactically broken YAML — the parser must return InvalidYaml.
+services:
+  api:
+    build: [unclosed bracket
+    image: nginx

--- a/tests/fixtures/compose/volume_named.yaml
+++ b/tests/fixtures/compose/volume_named.yaml
@@ -1,0 +1,10 @@
+# Fixture exercising a named volume mount and the corresponding top-level
+# volume declaration.
+services:
+  db:
+    image: postgres:15
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## v0.4.0 — Docker Compose service preview

### What's new

**Compose mode**
- `--compose <path> --service <name>` — preview the effective state of a Compose service
- Merges service `environment`, `env_file`, and `working_dir` into the simulation
- Volume mount shadows shown via `:mounts`
- `:services` — list all services in the Compose file
- `:depends` — show the dependency tree with cycle detection and diamond deduplication
- Warning when `--service` is used without `--compose`

**Security hardening (#60-#62)**
- Path traversal containment: `build.context` and `build.dockerfile` are now checked via `canonicalize() + starts_with()` against the compose directory
- `normalize_virtual_path()` resolves `..` in `working_dir` without touching the host FS; genuine root-escape emits `WorkdirEscapedRoot` warning
- `parse_env_file` correctly strips inline comments (space-prefixed `#`) and surrounding quote pairs per Docker Compose spec

**Correctness fixes (#63-#66)**
- `:depends`/`:services` warn when `selected_service` is absent from the service map
- `:depends` uses two-set DFS to correctly distinguish cycles from shared (diamond) subtrees
- `ReplError::Io` variant for terminal write failures (distinct from `InvalidArguments`)
- `warning: --service is only valid with --compose; ignoring` emitted to stderr

### Test stats
- 767 tests, 766 pass, 0 failures, 1 intentionally ignored doc-test
- All QA and security review HIGH findings resolved before merge

### Commits since v0.3.0
See the full commit log on `develop`.